### PR TITLE
Allow Relation.modelClass to refer ES6 class with default export.

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -199,7 +199,10 @@ Relation.prototype.setMapping = function (mapping) {
 
   if (_.isString(mapping.modelClass)) {
     try {
-      this.relatedModelClass = require(mapping.modelClass);
+      // babel 6 style of exposing es6 exports to commonjs https://github.com/babel/babel/issues/2683
+      var relatedModelClassModule = require(mapping.modelClass);
+      this.relatedModelClass = utils.isSubclassOf(relatedModelClassModule.default, Model) ?
+        relatedModelClassModule.default : relatedModelClassModule;
     } catch (err) {
       throw new Error(errorPrefix + '.modelClass is an invalid file path to a model class.');
     }


### PR DESCRIPTION
I was getting `....modelClass is an invalid file path to a model class.` error when relation had modelClass reference pointing to es6 class with default export.
