### PR TITLE
add schema support in models

### DIFF
--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -2477,6 +2477,10 @@ function build(builder) {
     // Set the table only if it hasn't been explicitly set yet.
     builder.table(builder._modelClass.tableName);
   }
+  
+  if (builder._modelClass.schemaName) {
+    builder.withSchema(builder._modelClass.schemaName);
+  }
 
   callBuilderFuncs(builder, context.onBuild);
   callBuilderFuncs(builder, internalContext.onBuild);


### PR DESCRIPTION
This simple commit adds ability to override the default schema in queries. 
Define schemaName in your model like this:
```javascript
class MyModel extends Model {
  static get schemaName() { return 'api'; }
}
```