### PR TITLE
fix for relation definitions of tables defined in schemas

### DIFF
--- a/src/relations/Relation.js
+++ b/src/relations/Relation.js
@@ -547,9 +547,10 @@ export default class Relation {
     let columns = [];
 
     for (let i = 0; i < ref.length; ++i) {
-      let parts = ref[i].split('.');
-      let tableName = parts[0] && parts[0].trim();
-      let columnName = parts[1] && parts[1].trim();
+      const refItem = ref[i];
+      const ndx = refItem.lastIndexOf('.');
+      let tableName = refItem.substr(0, ndx).trim();
+      let columnName = refItem.substr(ndx + 1, refItem.length).trim();
 
       if (!tableName || (table && table !== tableName) || !columnName) {
         return {

--- a/tests/unit/relations/Relation.js
+++ b/tests/unit/relations/Relation.js
@@ -362,4 +362,26 @@ describe('Relation', function () {
     expect(relation.relatedProp).to.eql(['ownerId']);
   });
 
+  it('should allow relations on tables under a schema', function () {
+    var relation = new Relation('testRelation', OwnerModel);
+    
+    OwnerModel.tableName = 'schema1.owner_model';
+    RelatedModel.tableName = 'schema2.related_model';
+
+    relation.setMapping({
+      relation: Relation,
+      modelClass: RelatedModel,
+      join: {
+        from: 'schema1.owner_model.id',
+        to: 'schema2.related_model.owner_id'
+      }
+    });
+
+    expect(relation.ownerModelClass).to.equal(OwnerModel);
+    expect(relation.relatedModelClass).to.equal(RelatedModel);
+    expect(relation.ownerCol).to.eql(['id']);
+    expect(relation.ownerProp).to.eql(['id']);
+    expect(relation.relatedCol).to.eql(['owner_id']);
+    expect(relation.relatedProp).to.eql(['owner_id']);
+  })
 });


### PR DESCRIPTION
Hi there, I was evaluating your awesome library when I stumbled upon a conflict between Objection relations and [PostgreSQL schemas](http://www.postgresql.org/docs/current/static/ddl-schemas.html).
With PostgreSQL schemas, a table named _my_table_ defined under the schema named _my_schema_ would be addressed as _my_schema.my_table_.

This PR (my first one, by the way) fixes a bug that when you are defining the _from_ and _to_ columns in a relation like
```
...
    join: {
        from: 'schema_name.model_name.column_name',
...
```
Objection interprets _schema_name_ as the table name and _model_name as_ the column name, discarding the rest.

I've added a test to the _Relation_ test suite to verify this fix and checked that all tests pass. However, I've observed that the test _"integration tests mysql Model find queries .$relatedQuery() many to many relation should return all related rows when no knex methods are chained"_ sometimes fails and sometimes not, but it seems that is not related to this PR.

Hope this helps.