### PR TITLE
Additional Query Builder Methods Added

### DIFF
--- a/src/queryBuilder/QueryBuilderBase.js
+++ b/src/queryBuilder/QueryBuilderBase.js
@@ -632,6 +632,48 @@ export default class QueryBuilderBase {
    * @returns {QueryBuilderBase}
    */
   @queryBuilderOperation(KnexOperation)
+  increment(...args) {}
+  
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  decrement(...args) {}
+
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  pluck(...args) {}
+
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  first(...args) {}
+
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  modify(...args) {}
+
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  columnInfo(...args) {}
+
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  options(...args) {}
+  
+  /**
+   * @returns {QueryBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
   debug(...args) {}
 
   /**


### PR DESCRIPTION
Some public methods available in Knex' query builder seems missing from objection's query builder.

`increment`, `decrement`, `pluck`, `first`, `modify`, `options`, `columnInfo` methods added.

Best Regards,