### PR TITLE
Bumped up maximum knex version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tv4-formats": "^1.0.2"
   },
   "peerDependencies": {
-    "knex": ">= 0.8.0 < 0.11.0"
+    "knex": ">= 0.8.0 < 0.11.5"
   },
   "devDependencies": {
     "babel-core": "^6.3.17",


### PR DESCRIPTION
Current max version of knex is 11.5, changes are not big to not include this