### PR TITLE
knex dependency bump to 0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.7.0"
   },
   "peerDependencies": {
-    "knex": ">= 0.8.0 <= 0.12.1"
+    "knex": ">= 0.8.0 <= 0.12.3"
   },
   "devDependencies": {
     "babel-core": "^6.3.17",
@@ -84,7 +84,7 @@
     "grunt": "^0.4.5",
     "grunt-jsdoc": "^1.0.0",
     "istanbul": "^0.4.0",
-    "knex": "0.12.1",
+    "knex": "0.12.3",
     "mocha": "^2.3.4",
     "mysql": "^2.7.0",
     "pg": "^4.4.0",


### PR DESCRIPTION
Bumps knexjs/knex to 0.12.3. Looks to be harmless and fixes a few annoyances which even @koskimas raised.

From knex CHANGELOG:

```
0.12.3 — 9 Oct, 2016
Fix #1703, #1694 - connections should be returned to pool if acquireConnectionTimeout is triggered
Fix #1710 regression in postgres array escaping

0.12.2 — 27 Sep, 2016
Restore pool min: 1 for sqlite3, #1701
Fix for connection error after it's closed / released, #1691
Fix oracle prefetchRowCount setting, #1675
```