### PR TITLE
[WIP] add custom jsonSchema string formats, fixes #199

### DIFF
--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -413,6 +413,14 @@ export default class ModelBase {
   }
 
   /**
+   * @param {String} name
+   * @param {String|RegExp|Function|Object} format
+   */
+  static addCustomFormat(name, format) {
+    ajv.addFormat(name, format);
+  }
+
+  /**
    * @param {Object} jsonSchema
    * @param {boolean} skipRequired
    * @returns {function}
@@ -761,3 +769,4 @@ function compileJsonSchemaValidator(jsonSchema, skipRequired) {
     }
   }
 }
+

--- a/tests/unit/model/ModelBase.js
+++ b/tests/unit/model/ModelBase.js
@@ -374,6 +374,24 @@ describe('ModelBase', function () {
       expect(model.c).not.to.equal(obj);
     });
 
+    it('should validate custom string formats', function () {
+      Model.addCustomFormat('se-ssn', /^[12]{1}[90]{1}[0-9]{6}-[0-9]{4}$/)
+
+      Model.jsonSchema = {
+        properties: {
+          a: {type: 'string', format: 'se-ssn'}
+        }
+      };
+
+      var model = Model.fromJson({a: '19851007-1234'});
+
+      expect(model.a).to.equal('19851007-1234');
+
+      expect(function () {
+        Model.fromJson({a: '198510071234'})
+      }).to.throwException()
+    });
+
     // regression introduced in 0.6
     // https://github.com/Vincit/objection.js/issues/205
     it('should not throw TypeError when jsonSchema.properties == undefined', function () {


### PR DESCRIPTION
This is a WIP as I haven't gotten to do the docs ...
Or actually, I did - but I destroyed the document somehow and I had to reset it.

Custom string formats would be added as expected by `ajv`:

``` js
// @returns void
objection.Model.addCustomFormat(string, /some-regex/);
objection.Model.addCustomFormat(string, { /* directly passed to ajv */ });
```

Currently this is somewhat at mercy of `ajv`, this maybe isn't as non opinionated as you'd like? 

I also exposed the internal `ajv` instance because I want/need to [add schema keywords](https://github.com/epoberezkin/ajv#addkeywordstring-keyword-object-definition) I opted not to add that to `ModelBase` yet as I'm not entirely sure how stable that spec is (by my understanding its a v5 proposal, implemented in `ajv` but not yet standardised)

``` js
// returns the ajv instance
objection.Model.schemaValidator().addKeyword(/* ... */)
```

My first implementation was a bit more complicated, which I reverted.
I had an idea of creating an objection.Validator class which basically acts as an interface and had the same methods implemented as used today - but I wasn't sure this was the direction you'd want to take it and I'm to noob actually draft a spec like that.
