### PR TITLE
Unleash ajv to set defaults and manage compiled schema cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "src/*"
   ],
   "dependencies": {
-    "ajv": "^4.1.5",
+    "ajv": "^4.8.2",
     "babel-runtime": "^6.6.1",
     "bluebird": "^3.4.6",
     "lodash": "^4.7.0"

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -66,6 +66,7 @@ export default class ModelBase {
     }
 
     const validator = this.constructor.getJsonSchemaValidator(jsonSchema, options.patch);
+    json = cloneObject(json);
     validator(json);
 
     if (validator.errors) {

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -159,7 +159,12 @@ export default class ModelBase {
     }
 
     if (!options.patch) {
-      json = mergeWithDefaults(this.constructor.getJsonSchema(), json);
+      let jsonSchema = this.constructor.getJsonSchema();
+
+      if (jsonSchema) {
+        json = cloneObject(json);
+        this.constructor.getJsonSchemaValidator(jsonSchema)(json);
+      }
     }
 
     // If the json contains query properties like, knex Raw queries or knex/objection query
@@ -496,44 +501,6 @@ export default class ModelBase {
     let columnName = _.first(_.difference(cols, addedCols));
 
     return columnName || null;
-  }
-}
-
-function mergeWithDefaults(jsonSchema, json) {
-  let merged = null;
-
-  if (!jsonSchema) {
-    return json;
-  }
-
-  if (!jsonSchema.properties) {
-    return json;
-  }
-
-  const propNames = Object.keys(jsonSchema.properties);
-  // Check each schema property for default value.
-  for (let i = 0, l = propNames.length; i < l; ++i) {
-    const propName = propNames[i];
-    const prop = jsonSchema.properties[propName];
-
-    if (!_.has(json, propName) && _.has(prop, 'default')) {
-      if (merged === null) {
-        // Only take expensive clone if needed.
-        merged = _.cloneDeep(json);
-      }
-
-      if (_.isObject(prop.default)) {
-        merged[propName] = _.cloneDeep(prop.default);
-      } else {
-        merged[propName] = prop.default;
-      }
-    }
-  }
-
-  if (merged === null) {
-    return json;
-  } else {
-    return merged;
   }
 }
 

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -13,6 +13,13 @@ const ajv = new Ajv({
   useDefaults: true,
   v5: true
 });
+const ajvNoDefaults = new Ajv({
+  allErrors: true,
+  validateSchema: false,
+  ownProperties: true,
+  useDefaults: false,
+  v5: true
+});
 const ajvCache = Object.create(null);
 
 /**
@@ -726,9 +733,10 @@ function compileJsonSchemaValidator(jsonSchema, skipRequired) {
     if (skipRequired) {
       origRequired = jsonSchema.required;
       jsonSchema.required = [];
+      return ajvNoDefaults.compile(jsonSchema);
+    } else {
+      return ajv.compile(jsonSchema);
     }
-
-    return ajv.compile(jsonSchema);
   } finally {
     if (skipRequired) {
       jsonSchema.required = origRequired;

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -6,7 +6,13 @@ import splitQueryProps from '../utils/splitQueryProps';
 import {inherits} from '../utils/classUtils';
 import memoize from '../utils/decorators/memoize';
 
-const ajv = new Ajv({allErrors: true, validateSchema: false, ownProperties: true});
+const ajv = new Ajv({
+  allErrors: true,
+  validateSchema: false,
+  ownProperties: true,
+  useDefaults: true,
+  v5: true
+});
 const ajvCache = Object.create(null);
 
 /**


### PR DESCRIPTION
I took the opportunity to enable v5 (see also #241) as well.
Fixes: #243.

I suspect this might not be mergeable "as is" but it's a starting point.