### PR TITLE
Add script for knex migrations in examples

### DIFF
--- a/examples/express-es6/README.md
+++ b/examples/express-es6/README.md
@@ -4,9 +4,8 @@
 git clone git@github.com:Vincit/objection.js.git objection
 cd objection/examples/express-es6
 npm install
-# We use knex for migrations in this example.
-npm install knex -g
-knex migrate:latest
+# Run knex migrations
+npm run db:migrate
 npm start
 ```
 

--- a/examples/express-es6/package.json
+++ b/examples/express-es6/package.json
@@ -4,7 +4,8 @@
   "description": "Objection.js express ES6 example",
   "main": "app.js",
   "scripts": {
-    "start": "node --harmony app"
+    "start": "node --harmony app",
+    "db:migrate": "knex migrate:latest"
   },
   "author": "Sami Koskimäki",
   "license": "MIT",

--- a/examples/express-es7/README.md
+++ b/examples/express-es7/README.md
@@ -4,9 +4,8 @@
 git clone git@github.com:Vincit/objection.js.git objection
 cd objection/examples/express-es7
 npm install
-# We use knex for migrations in this example.
-npm install knex -g
-knex migrate:latest
+# Run knex migrations
+npm run db:migrate
 # This runs the Babel transpiler and executes the app.
 npm start
 ```

--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "babel-node --presets stage-0,es2015 --plugins transform-class-properties app",
+    "db:migrate": "knex migrate:latest"
   },
   "author": "Sami Koskimäki",
   "license": "MIT",

--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -4,7 +4,7 @@
   "description": "Objection.js express ES7 example",
   "main": "app.js",
   "scripts": {
-    "start": "node_modules/babel-cli/bin/babel-node.js --presets stage-0,es2015 --plugins transform-class-properties app"
+    "start": "babel-node --presets stage-0,es2015 --plugins transform-class-properties app",
   },
   "author": "Sami Koskimäki",
   "license": "MIT",


### PR DESCRIPTION
Knex is already declared as a dependency, so we could be using the knex CLI tool directly and avoid asking users to install a global dependency. `db:migrate` might not be the best name, so if you think it should be called something else please let me know.

The other change I propose is that since `node_modules/.bin` is in the path for npm scripts and `babel-cli` makes `babel-node` available through that folder, we use that instead of hardcoding the full path to the file (which may change in a future version of babel).

If you think this should be proposed in different PRs, please let know and I will happily split them out :)