### PR TITLE
Initial ref syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # .travis.yml
 language: node_js
 
+sudo: required
+
 node_js:
   - '0.10'
   - '0.12'
@@ -22,4 +24,4 @@ notifications:
   email: false
 
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import ModelBase from './ModelBase';
 import QueryBuilder from '../queryBuilder/QueryBuilder';
+import ReferenceBuilder from '../queryBuilder/ReferenceBuilder';
 import inheritModel from './inheritModel';
 import RelationExpression from '../queryBuilder/RelationExpression';
 import {inheritHiddenData} from '../utils/hiddenData';
@@ -23,6 +24,7 @@ import JoinEagerOperation from '../queryBuilder/operations/JoinEagerOperation';
 import WhereInEagerOperation from '../queryBuilder/operations/WhereInEagerOperation';
 
 const KnexRaw = require('knex/lib/raw');
+const KnexQueryBuilder = require('knex/lib/query/builder');
 
 const JoinEagerAlgorithm = () => {
   return new JoinEagerOperation('eager');
@@ -267,7 +269,8 @@ export default class Model extends ModelBase {
         const attr = jsonAttr[i];
         const value = json[attr];
 
-        if (_.isObject(value) && !(value instanceof KnexRaw)) {
+        // list of omitted objects is copy pasted from splitQueryProps
+        if (_.isObject(value) && !(value instanceof KnexQueryBuilder || value instanceof KnexRaw || value instanceof ReferenceBuilder)) {
           json[attr] = JSON.stringify(value);
         }
       }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -22,6 +22,8 @@ import InstanceDeleteOperation from '../queryBuilder/operations/InstanceDeleteOp
 import JoinEagerOperation from '../queryBuilder/operations/JoinEagerOperation';
 import WhereInEagerOperation from '../queryBuilder/operations/WhereInEagerOperation';
 
+const KnexRaw = require('knex/lib/raw');
+
 const JoinEagerAlgorithm = () => {
   return new JoinEagerOperation('eager');
 };
@@ -245,7 +247,11 @@ export default class Model extends ModelBase {
         const value = json[attr];
 
         if (_.isString(value)) {
-          json[attr] = JSON.parse(value);
+          try {
+            json[attr] = JSON.parse(value);
+          } catch (err) {
+            // json column might contain plain single string which is not wrapped to array / object
+          }
         }
       }
     }
@@ -261,7 +267,7 @@ export default class Model extends ModelBase {
         const attr = jsonAttr[i];
         const value = json[attr];
 
-        if (_.isObject(value)) {
+        if (_.isObject(value) && !(value instanceof KnexRaw)) {
           json[attr] = JSON.stringify(value);
         }
       }

--- a/src/objection.js
+++ b/src/objection.js
@@ -15,6 +15,7 @@ import BelongsToOneRelation from './relations/belongsToOne/BelongsToOneRelation'
 import ManyToManyRelation from './relations/manyToMany/ManyToManyRelation';
 
 import transaction from './transaction';
+import { ref } from './queryBuilder/ReferenceBuilder';
 import Promise from 'bluebird';
 
 export {
@@ -33,6 +34,7 @@ export {
   BelongsToOneRelation,
   ManyToManyRelation,
   transaction,
-  Promise
+  Promise,
+  ref
 };
 

--- a/src/queryBuilder/JoinBuilder.js
+++ b/src/queryBuilder/JoinBuilder.js
@@ -1,0 +1,194 @@
+import _ from 'lodash';
+import queryBuilderOperation from './decorators/queryBuilderOperation';
+import {inherits} from '../utils/classUtils';
+
+import QueryBuilderContextBase from './QueryBuilderContextBase';
+
+import QueryBuilderBase from './QueryBuilderBase';
+import KnexOperation from './operations/KnexOperation';
+
+// TODO: Seaparate basecode without any wrapped APIs to base now 
+//       join builder has way too many inherited methods...
+export default class JoinBuilder extends QueryBuilderBase {
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  using(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  on(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onBetween(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onNotBetween(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnBetween(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnNotBetween(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onNotIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnNotIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onNotNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnNotNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  onNotExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  orOnNotExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  type(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  or(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnNotIn(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnNotNull(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnNotExists(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnBetween(...args) {}
+
+  /**
+   * @returns {JoinBuilderBase}
+   */
+  @queryBuilderOperation(KnexOperation)
+  andOnNotBetween(...args) {}
+
+}

--- a/src/queryBuilder/JoinBuilder.js
+++ b/src/queryBuilder/JoinBuilder.js
@@ -1,15 +1,12 @@
 import _ from 'lodash';
+import QueryBuilderOperationSupport from './QueryBuilderOperationSupport';
 import queryBuilderOperation from './decorators/queryBuilderOperation';
 import {inherits} from '../utils/classUtils';
 
 import QueryBuilderContextBase from './QueryBuilderContextBase';
-
-import QueryBuilderBase from './QueryBuilderBase';
 import KnexOperation from './operations/KnexOperation';
 
-// TODO: Seaparate basecode without any wrapped APIs to base now 
-//       join builder has way too many inherited methods...
-export default class JoinBuilder extends QueryBuilderBase {
+export default class JoinBuilder extends QueryBuilderOperationSupport {
 
   /**
    * @returns {JoinBuilderBase}

--- a/src/queryBuilder/QueryBuilderBase.js
+++ b/src/queryBuilder/QueryBuilderBase.js
@@ -5,6 +5,7 @@ import {inherits} from '../utils/classUtils';
 import QueryBuilderContextBase from './QueryBuilderContextBase';
 
 import KnexOperation from './operations/KnexOperation';
+
 import SelectOperation from './operations/SelectOperation';
 import WhereRefOperation from './operations/WhereRefOperation';
 import WhereCompositeOperation from './operations/WhereCompositeOperation';

--- a/src/queryBuilder/QueryBuilderBase.js
+++ b/src/queryBuilder/QueryBuilderBase.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import queryBuilderOperation from './decorators/queryBuilderOperation';
 import {inherits} from '../utils/classUtils';
 
-import QueryBuilderContextBase from './QueryBuilderContextBase';
+import QueryBuilderOperationSupport from './QueryBuilderOperationSupport';
 
 import KnexOperation from './operations/KnexOperation';
 
@@ -22,95 +22,17 @@ import WhereJsonNotObjectPostgresOperation from './operations/jsonApi/WhereJsonN
  * query builder methods without monkey patching knex query builder.
  */
 
-export default class QueryBuilderBase {
-
-  constructor(knex, QueryBuilderContext) {
-    /**
-     * @type {knex}
-     * @protected
-     */
-    this._knex = knex;
-    /**
-     * @type {Array.<QueryBuilderOperation>}
-     * @protected
-     */
-    this._operations = [];
-    /**
-     * @type {QueryBuilderContextBase}
-     * @protected
-     */
-    this._context = new (QueryBuilderContext || QueryBuilderContextBase)(this._createUserContextBase());
-  }
+export default class QueryBuilderBase extends QueryBuilderOperationSupport {
 
   static SelectRegex = /^(select|sum|min|max|count|avg)$/;
   static WhereRegex = /where|orWhere|andWhere/;
   static FromRegex = /^(from|into|table)$/;
 
   /**
-   * @param {function=} subclassConstructor
-   * @return {Constructor.<QueryBuilderBase>}
+   * @return {boolean}
    */
-  static extend(subclassConstructor) {
-    inherits(subclassConstructor, this);
-    return subclassConstructor;
-  }
-
-  /**
-   * @param {Object=} ctx
-   * @returns {Object|QueryBuilderBase}
-   */
-  context(ctx) {
-    if (arguments.length === 0) {
-      return this._context.userContext;
-    } else {
-      const ctxBase = this._createUserContextBase();
-      this._context.userContext = Object.assign(ctxBase, ctx);
-      return this;
-    }
-  }
-
-  /**
-   * @param {Object=} ctx
-   * @returns {QueryBuilderBase}
-   */
-  mergeContext(ctx) {
-    const oldCtx = this._context.userContext;
-    this._context.userContext = Object.assign(oldCtx, ctx);
-    return this;
-  }
-
-  /**
-   * @param {QueryBuilderContextBase=} ctx
-   * @returns {QueryBuilderContextBase|QueryBuilderBase}
-   */
-  internalContext(ctx) {
-    if (arguments.length === 0) {
-      return this._context;
-    } else {
-      this._context = ctx;
-      return this;
-    }
-  }
-
-  /**
-   * @param {knex=} knex
-   * @returns {Object|QueryBuilderBase}
-   */
-  knex(knex) {
-    if (arguments.length === 0) {
-      const knex = this._context.knex || this._knex;
-
-      if (!knex) {
-        throw new Error(
-          `no database connection available for a query for table ${this.modelClass().tableName}. ` +
-          `You need to bind the model class or the query to a knex instance.`);
-      }
-
-      return knex;
-    } else {
-      this._knex = knex;
-      return this;
-    }
+  isSelectAll() {
+    return !this.has(QueryBuilderBase.SelectRegex) && !this.has(QueryBuilderBase.WhereRegex);
   }
 
   /**
@@ -139,252 +61,12 @@ export default class QueryBuilderBase {
   }
 
   /**
-   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
-   * @return {QueryBuilderBase}
-   */
-  clear(operationSelector) {
-    const operations = [];
-
-    this.forEachOperation(operationSelector, (op) => {
-      operations.push(op);
-    }, false);
-
-    this._operations = operations;
-    return this;
-  }
-
-  /**
-   * @param {QueryBuilderBase} queryBuilder
-   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
-   * @return {QueryBuilderBase}
-   */
-  copyFrom(queryBuilder, operationSelector) {
-    queryBuilder.forEachOperation(operationSelector, (op) => {
-      this._operations.push(op);
-    });
-
-    return this;
-  }
-
-  /**
-   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
-   * @returns {boolean}
-   */
-  has(operationSelector) {
-    let found = false;
-
-    this.forEachOperation(operationSelector, () => {
-      found = true;
-      return false;
-    });
-
-    return found;
-  }
-
-  /**
-   * @return {boolean}
-   */
-  isSelectAll() {
-    return !this.has(QueryBuilderBase.SelectRegex) && !this.has(QueryBuilderBase.WhereRegex);
-  }
-
-  /**
-   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
-   * @returns {boolean}
-   */
-  indexOfOperation(operationSelector) {
-    let idx = -1;
-
-    this.forEachOperation(operationSelector, (op, i) => {
-      idx = i;
-      return false;
-    });
-
-    return idx;
-  }
-
-  /**
-   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
-   * @param {function(QueryBuilderOperation)} callback
-   * @param {boolean} match
-   * @returns {QueryBuilderBase}
-   */
-  forEachOperation(operationSelector, callback, match = true) {
-    if (_.isRegExp(operationSelector)) {
-      for (let i = 0, l = this._operations.length; i < l; ++i) {
-        const op = this._operations[i];
-
-        if (operationSelector.test(op.name) === match) {
-          if (callback(op, i) === false) {
-            break;
-          }
-        }
-      }
-    } else {
-      for (let i = 0, l = this._operations.length; i < l; ++i) {
-        const op = this._operations[i];
-
-        if ((op instanceof operationSelector) === match) {
-          if (callback(op, i) === false) {
-            break;
-          }
-        }
-      }
-    }
-
-    return this;
-  }
-
-  /**
-   * @param {QueryBuilderOperation} operation
-   * @param {Array.<*>} args
-   * @param {Boolean=} pushFront
-   * @returns {QueryBuilderBase}
-   */
-   callQueryBuilderOperation(operation, args, pushFront) {
-    if (operation.call(this, args || [])) {
-      if (pushFront) {
-        this._operations.splice(0, 0, operation);
-      } else {
-        this._operations.push(operation);
-      }
-    }
-
-    return this;
-  }
-
-  /**
-   * @param {string} methodName
-   * @param {Array.<*>} args
-   * @returns {QueryBuilderBase}
-   */
-  callKnexQueryBuilderOperation(methodName, args, pushFront) {
-    return this.callQueryBuilderOperation(new KnexOperation(methodName), args, pushFront);
-  }
-
-  /**
-   * @returns {QueryBuilderBase}
-   */
-  clone() {
-    return this.baseCloneInto(new this.constructor(this.knex()));
-  }
-
-  /**
-   * @protected
-   * @returns {QueryBuilderBase}
-   */
-  baseCloneInto(builder) {
-    builder._knex = this._knex;
-    builder._operations = this._operations.slice();
-    builder._context = this._context.clone();
-
-    return builder;
-  }
-
-  /**
-   * @returns {knex.QueryBuilder}
-   */
-  build() {
-    return this.buildInto(this.knex().queryBuilder());
-  }
-
-  /**
-   * @protected
-   */
-  buildInto(knexBuilder) {
-    const tmp = new Array(10);
-
-    let i = 0;
-    while (i < this._operations.length) {
-      const op = this._operations[i];
-      const ln = this._operations.length;
-
-      op.onBeforeBuild(this);
-
-      const numNew = this._operations.length - ln;
-
-      // onBeforeBuild may call methods that add more operations. If
-      // this was the case, move the operations to be executed next.
-      if (numNew > 0) {
-        while (tmp.length < numNew) {
-          tmp.push(null);
-        }
-
-        for (let j = 0; j < numNew; ++j) {
-          tmp[j] = this._operations[ln + j];
-        }
-
-        for (let j = ln + numNew - 1; j > i + numNew; --j) {
-          this._operations[j] = this._operations[j - numNew];
-        }
-
-        for (let j = 0; j < numNew; ++j) {
-          this._operations[i + j + 1] = tmp[j];
-        }
-      }
-
-      ++i;
-    }
-
-    // onBuild operations should never add new operations. They should only call
-    // methods on the knex query builder.
-    for (let i = 0, l = this._operations.length; i < l; ++i) {
-      this._operations[i].onBuild(knexBuilder, this)
-    }
-
-    return knexBuilder;
-  }
-
-  /**
-   * @returns {string}
-   */
-  toString() {
-    return this.build().toString();
-  }
-
-  /**
-   * @returns {string}
-   */
-  toSql() {
-    return this.toString();
-  }
-
-  /**
-   * @returns {QueryBuilderBase}
-   */
-  skipUndefined() {
-    this._context.skipUndefined = true;
-    return this;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  shouldSkipUndefined() {
-    return this._context.skipUndefined;
-  }
-
-  /**
    * @param {Transaction} trx
    * @returns {QueryBuilderBase}
    */
   transacting(trx) {
     this._context.knex = trx || null;
     return this;
-  }
-
-  /**
-   * @private
-   */
-  _createUserContextBase() {
-    const ctxProto = {};
-
-    Object.defineProperty(ctxProto, 'transaction', {
-      enumerable: false,
-      get: () => this.knex()
-    });
-
-    return Object.create(ctxProto);
   }
 
   /**

--- a/src/queryBuilder/QueryBuilderOperationSupport.js
+++ b/src/queryBuilder/QueryBuilderOperationSupport.js
@@ -1,0 +1,331 @@
+import _ from 'lodash';
+import {inherits} from '../utils/classUtils';
+import QueryBuilderContextBase from './QueryBuilderContextBase';
+import KnexOperation from './operations/KnexOperation';
+
+/**
+ * Base functionality to be able to use query builder operation annotations.
+ */
+
+export default class QueryBuilderOperationSupport {
+
+  constructor(knex, QueryBuilderContext) {
+    /**
+     * @type {knex}
+     * @protected
+     */
+    this._knex = knex;
+    /**
+     * @type {Array.<QueryBuilderOperation>}
+     * @protected
+     */
+    this._operations = [];
+    /**
+     * @type {QueryBuilderContextBase}
+     * @protected
+     */
+    this._context = new (QueryBuilderContext || QueryBuilderContextBase)(this._createUserContextBase());
+  }
+
+  /**
+   * @param {function=} subclassConstructor
+   * @return {Constructor.<QueryBuilderOperationSupport>}
+   */
+  static extend(subclassConstructor) {
+    inherits(subclassConstructor, this);
+    return subclassConstructor;
+  }
+
+  /**
+   * @param {Object=} ctx
+   * @returns {Object|QueryBuilderOperationSupport}
+   */
+  context(ctx) {
+    if (arguments.length === 0) {
+      return this._context.userContext;
+    } else {
+      const ctxBase = this._createUserContextBase();
+      this._context.userContext = Object.assign(ctxBase, ctx);
+      return this;
+    }
+  }
+
+  /**
+   * @param {Object=} ctx
+   * @returns {QueryBuilderOperationSupport}
+   */
+  mergeContext(ctx) {
+    const oldCtx = this._context.userContext;
+    this._context.userContext = Object.assign(oldCtx, ctx);
+    return this;
+  }
+
+  /**
+   * @param {QueryBuilderContextBase=} ctx
+   * @returns {QueryBuilderContextBase|QueryBuilderOperationSupport}
+   */
+  internalContext(ctx) {
+    if (arguments.length === 0) {
+      return this._context;
+    } else {
+      this._context = ctx;
+      return this;
+    }
+  }
+
+  /**
+   * @param {knex=} knex
+   * @returns {Object|QueryBuilderOperationSupport}
+   */
+  knex(knex) {
+    if (arguments.length === 0) {
+      const knex = this._context.knex || this._knex;
+
+      if (!knex) {
+        throw new Error(
+          `no database connection available for a query for table ${this.modelClass().tableName}. ` +
+          `You need to bind the model class or the query to a knex instance.`);
+      }
+
+      return knex;
+    } else {
+      this._knex = knex;
+      return this;
+    }
+  }
+
+
+  /**
+   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
+   * @return {QueryBuilderBase}
+   */
+  clear(operationSelector) {
+    const operations = [];
+
+    this.forEachOperation(operationSelector, (op) => {
+      operations.push(op);
+    }, false);
+
+    this._operations = operations;
+    return this;
+  }
+
+  /**
+   * @param {QueryBuilderBase} queryBuilder
+   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
+   * @return {QueryBuilderBase}
+   */
+  copyFrom(queryBuilder, operationSelector) {
+    queryBuilder.forEachOperation(operationSelector, (op) => {
+      this._operations.push(op);
+    });
+
+    return this;
+  }
+
+  /**
+   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
+   * @returns {boolean}
+   */
+  has(operationSelector) {
+    let found = false;
+
+    this.forEachOperation(operationSelector, () => {
+      found = true;
+      return false;
+    });
+
+    return found;
+  }
+
+
+  /**
+   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
+   * @returns {boolean}
+   */
+  indexOfOperation(operationSelector) {
+    let idx = -1;
+
+    this.forEachOperation(operationSelector, (op, i) => {
+      idx = i;
+      return false;
+    });
+
+    return idx;
+  }
+
+  /**
+   * @param {RegExp|Constructor.<? extends QueryBuilderOperation>} operationSelector
+   * @param {function(QueryBuilderOperation)} callback
+   * @param {boolean} match
+   * @returns {QueryBuilderBase}
+   */
+  forEachOperation(operationSelector, callback, match = true) {
+    if (_.isRegExp(operationSelector)) {
+      for (let i = 0, l = this._operations.length; i < l; ++i) {
+        const op = this._operations[i];
+
+        if (operationSelector.test(op.name) === match) {
+          if (callback(op, i) === false) {
+            break;
+          }
+        }
+      }
+    } else {
+      for (let i = 0, l = this._operations.length; i < l; ++i) {
+        const op = this._operations[i];
+
+        if ((op instanceof operationSelector) === match) {
+          if (callback(op, i) === false) {
+            break;
+          }
+        }
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * @param {QueryBuilderOperation} operation
+   * @param {Array.<*>} args
+   * @param {Boolean=} pushFront
+   * @returns {QueryBuilderOperationSupport}
+   */
+   callQueryBuilderOperation(operation, args, pushFront) {
+    if (operation.call(this, args || [])) {
+      if (pushFront) {
+        this._operations.splice(0, 0, operation);
+      } else {
+        this._operations.push(operation);
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * @param {string} methodName
+   * @param {Array.<*>} args
+   * @returns {QueryBuilderOperationSupport}
+   */
+  callKnexQueryBuilderOperation(methodName, args, pushFront) {
+    return this.callQueryBuilderOperation(new KnexOperation(methodName), args, pushFront);
+  }
+
+  /**
+   * @returns {QueryBuilderOperationSupport}
+   */
+  clone() {
+    return this.baseCloneInto(new this.constructor(this.knex()));
+  }
+
+  /**
+   * @protected
+   * @returns {QueryBuilderOperationSupport}
+   */
+  baseCloneInto(builder) {
+    builder._knex = this._knex;
+    builder._operations = this._operations.slice();
+    builder._context = this._context.clone();
+
+    return builder;
+  }
+
+  /**
+   * @returns {knex.QueryBuilder}
+   */
+  build() {
+    return this.buildInto(this.knex().queryBuilder());
+  }
+
+  /**
+   * @protected
+   */
+  buildInto(knexBuilder) {
+    const tmp = new Array(10);
+
+    let i = 0;
+    while (i < this._operations.length) {
+      const op = this._operations[i];
+      const ln = this._operations.length;
+
+      op.onBeforeBuild(this);
+
+      const numNew = this._operations.length - ln;
+
+      // onBeforeBuild may call methods that add more operations. If
+      // this was the case, move the operations to be executed next.
+      if (numNew > 0) {
+        while (tmp.length < numNew) {
+          tmp.push(null);
+        }
+
+        for (let j = 0; j < numNew; ++j) {
+          tmp[j] = this._operations[ln + j];
+        }
+
+        for (let j = ln + numNew - 1; j > i + numNew; --j) {
+          this._operations[j] = this._operations[j - numNew];
+        }
+
+        for (let j = 0; j < numNew; ++j) {
+          this._operations[i + j + 1] = tmp[j];
+        }
+      }
+
+      ++i;
+    }
+
+    // onBuild operations should never add new operations. They should only call
+    // methods on the knex query builder.
+    for (let i = 0, l = this._operations.length; i < l; ++i) {
+      this._operations[i].onBuild(knexBuilder, this)
+    }
+
+    return knexBuilder;
+  }
+
+  /**
+   * @returns {string}
+   */
+  toString() {
+    return this.build().toString();
+  }
+
+  /**
+   * @returns {string}
+   */
+  toSql() {
+    return this.toString();
+  }
+
+  /**
+   * @returns {QueryBuilderOperationSupport}
+   */
+  skipUndefined() {
+    this._context.skipUndefined = true;
+    return this;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  shouldSkipUndefined() {
+    return this._context.skipUndefined;
+  }
+
+  /**
+   * @private
+   */
+  _createUserContextBase() {
+    const ctxProto = {};
+
+    Object.defineProperty(ctxProto, 'transaction', {
+      enumerable: false,
+      get: () => this.knex()
+    });
+
+    return Object.create(ctxProto);
+  }
+}

--- a/src/queryBuilder/ReferenceBuilder.js
+++ b/src/queryBuilder/ReferenceBuilder.js
@@ -1,0 +1,66 @@
+import jsonFieldExpressionParser from './parsers/jsonFieldExpressionParser';
+
+export default class ReferenceBuilder {
+
+  constructor(fieldExpression) {
+    this._reference = jsonFieldExpressionParser.parse(fieldExpression);
+    this._cast = null;
+  }
+
+  asText() {
+    return this.asType('text');
+  }
+
+  asInt() {
+    return this.asType('integer');
+  }
+
+  asBigInt() {
+    return this.asType('bigint');
+  }
+
+  asFloat() {
+    return this.asType('float');
+  }
+
+  asDecimal() {
+    return this.asType('decimal');
+  }
+
+  asReal() {
+    return this.asType('real');
+  }
+
+  asBool() {
+    return this.asType('boolean');
+  }
+
+  asJsonb() {
+    return this.asType('jsonb');
+  }
+
+  asType(sqlType) {
+    // we could maybe check some valid values here... at least fail on invalid chars 
+    this._cast = sqlType;
+    return this;
+  }
+
+  toRawArgs() {
+    let referenceSql = `??`;
+ 
+    // if json field ref
+    if (this._reference.access.length > 0) {
+      // TODO: for mysql this needs separate implementation... maybe something like SELECT JSON_EXTRACT('{"id": 14, "name": "Aztalan"}', '$.name');
+      let extractor = this._cast ? '#>>' : '#>';
+      let jsonFieldRef = this._reference.access.map(field => field.ref).join(',');  
+      referenceSql = `??${extractor}'{${jsonFieldRef}}'`;
+    }
+    let query = this._cast ? `CAST(${referenceSql} AS ${this._cast})` : referenceSql;
+    return [query, [this._reference.columnName]];
+  }
+
+}
+
+let ref = fieldExpression => new ReferenceBuilder(fieldExpression);
+
+export { ref };

--- a/src/queryBuilder/ReferenceBuilder.js
+++ b/src/queryBuilder/ReferenceBuilder.js
@@ -68,9 +68,12 @@ export default class ReferenceBuilder {
 
     let castedRefQuery = this._cast ? `CAST(${referenceSql} AS ${this._cast})` : referenceSql;
     let toJsonQuery = this._toJson ? `to_jsonb(${castedRefQuery})` : castedRefQuery;
-    let assedAndCastedRefQuery = this._as ? `${toJsonQuery} AS ${this._as}` : toJsonQuery;
 
-    return [assedAndCastedRefQuery, [this._reference.columnName]];
+    if (this._as) {
+      return [`${toJsonQuery} AS ??`, [this._reference.columnName, this._as]];
+    } else {
+      return [toJsonQuery, [this._reference.columnName]];
+    }
   }
 
 }

--- a/src/queryBuilder/decorators/queryBuilderOperation.js
+++ b/src/queryBuilder/decorators/queryBuilderOperation.js
@@ -6,7 +6,6 @@ export default function queryBuilderOperation(input, name) {
 
   return function (target, property, descriptor) {
     const operationName = name || property;
-
     if (_.isFunction(input) || _.isArray(input)) {
       descriptor.value = function decorator$queryBuilderOperation() {
         const args = new Array(arguments.length);

--- a/src/queryBuilder/operations/SelectOperation.js
+++ b/src/queryBuilder/operations/SelectOperation.js
@@ -31,12 +31,13 @@ export default class SelectOperation extends WrappingQueryBuilderOperation {
   }
 
   call(builder, args) {
-    const ret = super.call(builder, args);
+    // treat select(['1','2','3']) and select('1','2','3') the same way
+    const normalizedArgs = (args.length === 1 && Array.isArray(args[0])) ? args[0] : args;
+    const ret = super.call(builder, normalizedArgs);
     const selections = _.flatten(this.args);
 
     for (let i = 0, l = selections.length; i < l; ++i) {
       const selection = SelectOperation.parseSelection(selections[i]);
-
       if (selection) {
         this.selections.push(selection);
       }

--- a/src/queryBuilder/operations/SelectOperation.js
+++ b/src/queryBuilder/operations/SelectOperation.js
@@ -31,10 +31,8 @@ export default class SelectOperation extends WrappingQueryBuilderOperation {
   }
 
   call(builder, args) {
-    // treat select(['1','2','3']) and select('1','2','3') the same way
-    const normalizedArgs = (args.length === 1 && Array.isArray(args[0])) ? args[0] : args;
-    const ret = super.call(builder, normalizedArgs);
-    const selections = _.flatten(this.args);
+    const selections = _.flatten(args);
+    const ret = super.call(builder, selections);
 
     for (let i = 0, l = selections.length; i < l; ++i) {
       const selection = SelectOperation.parseSelection(selections[i]);

--- a/src/queryBuilder/operations/UpdateOperation.js
+++ b/src/queryBuilder/operations/UpdateOperation.js
@@ -17,6 +17,36 @@ export default class UpdateOperation extends QueryBuilderOperation {
   }
 
   call(builder, args) {
+    // convert ref syntax to knex.raw
+    // TODO: jsonb attr update implementation for mysql and sqlite..
+    const knex = builder.knex();
+
+    _.forOwn(args[0], (val, key) => {
+      // convert ref values to raw
+      let loweredValue = (val instanceof ReferenceBuilder) ?
+        knex.raw(...(val.toRawArgs())) : val;
+
+      // convert update to jsonb_set format if attr inside jsonb column is set
+      if (key.indexOf(':') > -1) {
+        // e.g. 'col:attr' : ref('other:lol') is transformed to
+        // "col" : raw(`jsonb_set("col", '{attr}', to_jsonb("other"#>'{lol}'), true)`)
+
+        let parsed = jsonFieldExpressionParser.parse(key);
+        let jsonRefs = '{' + _(parsed.access).map('ref').value().join(',') + '}';
+
+        args[0][parsed.columnName] = knex.raw(
+          `jsonb_set(??, '${jsonRefs}', to_jsonb(?), true)`,
+          [parsed.columnName, loweredValue]
+        );
+        // (looks like I just can't set new stuff to args[0] that
+        //  would be the converted object so I just modify the
+        //  original args|0] object)
+        delete args[0][key];
+      } else {
+        args[0][key] = loweredValue;
+      }
+    });
+
     this.model = builder.modelClass().ensureModel(args[0], this.modelOptions);
     return true;
   }
@@ -28,34 +58,7 @@ export default class UpdateOperation extends QueryBuilderOperation {
 
   onBuild(knexBuilder, builder) {
     const json = this.model.$toDatabaseJson();
-
-    // TODO: jsonb attr update implementation for mysql and sqlite..
-    const loweredJson = {};
-
-    _.forOwn(json, (val, key) => {
-      // convert ref values to raw
-      let loweredValue = (val instanceof ReferenceBuilder) ?
-        knexBuilder.client.raw(...(val.toRawArgs())) : val;
-
-
-      // convert update to jsonb_set format if attr inside jsonb column is set
-      if (key.indexOf(':') > -1) {
-        // e.g. 'col:attr' : ref('other:lol') is transformed to
-        // "col" : raw(`jsonb_set("col", '{attr}', to_jsonb("other"#>'{lol}'), true)`)
-
-        let parsed = jsonFieldExpressionParser.parse(key);
-        let jsonRefs = '{' + _(parsed.access).map('ref').value().join(',') + '}';
-
-        loweredJson[parsed.columnName] = knexBuilder.client.raw(
-          `jsonb_set(??, '${jsonRefs}', to_jsonb(?), true)`,
-          [parsed.columnName, loweredValue]
-        );
-      } else {
-        loweredJson[key] = loweredValue;
-      }
-    });
-
-    knexBuilder.update(loweredJson);
+    knexBuilder.update(json);
   }
 
   onAfterInternal(builder, numUpdated) {

--- a/src/queryBuilder/operations/UpdateOperation.js
+++ b/src/queryBuilder/operations/UpdateOperation.js
@@ -1,6 +1,10 @@
+import _ from 'lodash';
 import clone from 'lodash/clone';
 import QueryBuilderOperation from './QueryBuilderOperation';
+import ReferenceBuilder from '../ReferenceBuilder';
+import jsonFieldExpressionParser from '../parsers/jsonFieldExpressionParser';
 import {afterReturn} from '../../utils/promiseUtils';
+
 
 export default class UpdateOperation extends QueryBuilderOperation {
 
@@ -24,7 +28,34 @@ export default class UpdateOperation extends QueryBuilderOperation {
 
   onBuild(knexBuilder, builder) {
     const json = this.model.$toDatabaseJson();
-    knexBuilder.update(json);
+
+    // TODO: jsonb attr update implementation for mysql and sqlite..
+    const loweredJson = {};
+
+    _.forOwn(json, (val, key) => {
+      // convert ref values to raw
+      let loweredValue = (val instanceof ReferenceBuilder) ?
+        knexBuilder.client.raw(...(val.toRawArgs())) : val;
+
+
+      // convert update to jsonb_set format if attr inside jsonb column is set
+      if (key.indexOf(':') > -1) {
+        // e.g. 'col:attr' : ref('other:lol') is transformed to
+        // "col" : raw(`jsonb_set("col", '{attr}', to_jsonb("other"#>'{lol}'), true)`)
+
+        let parsed = jsonFieldExpressionParser.parse(key);
+        let jsonRefs = '{' + _(parsed.access).map('ref').value().join(',') + '}';
+
+        loweredJson[parsed.columnName] = knexBuilder.client.raw(
+          `jsonb_set(??, '${jsonRefs}', to_jsonb(?), true)`,
+          [parsed.columnName, loweredValue]
+        );
+      } else {
+        loweredJson[key] = loweredValue;
+      }
+    });
+
+    knexBuilder.update(loweredJson);
   }
 
   onAfterInternal(builder, numUpdated) {

--- a/src/queryBuilder/operations/WrappingQueryBuilderOperation.js
+++ b/src/queryBuilder/operations/WrappingQueryBuilderOperation.js
@@ -78,8 +78,7 @@ function wrapFunctionArg(func, knex) {
       joinClauseBuilder.buildInto(knexQueryBuilder);
 
     } else {
-      // This case is for function argument `join` operation and other methods that
-      // Don't take a query builder as the first parameter.
+      // maybe someone falls here to the original knex implementation
       return func.apply(this, arguments);
     }
   };

--- a/src/utils/dbUtils.js
+++ b/src/utils/dbUtils.js
@@ -1,4 +1,5 @@
 import KnexQueryBuilder from 'knex/lib/query/builder'
+import JoinClause from 'knex/lib/query/joinclause'
 
 export function getDialect(knex) {
   return (knex && knex.client && knex.client.dialect) || null;
@@ -18,4 +19,8 @@ export function isSqlite(knex) {
 
 export function isKnexQueryBuilder(knexQueryBuilder) {
   return knexQueryBuilder instanceof KnexQueryBuilder;
+}
+
+export function isKnexJoinBuilder(knexQueryBuilder) {
+  return knexQueryBuilder instanceof JoinClause;
 }

--- a/src/utils/splitQueryProps.js
+++ b/src/utils/splitQueryProps.js
@@ -1,11 +1,13 @@
 const KnexQueryBuilder = require('knex/lib/query/builder');
 const KnexRaw = require('knex/lib/raw');
 let QueryBuilderBase = null;
+let ReferenceBuilder = null;
 
 export default function (ModelClass, obj) {
   if (QueryBuilderBase === null) {
     // Lazy loading to prevent circular deps.
     QueryBuilderBase = require('../queryBuilder/QueryBuilderBase').default;
+    ReferenceBuilder = require('../queryBuilder/ReferenceBuilder').default;
   }
 
   const keys = Object.keys(obj);
@@ -15,7 +17,7 @@ export default function (ModelClass, obj) {
     const key = keys[i];
     const value = obj[key];
 
-    if (value instanceof KnexQueryBuilder || value instanceof QueryBuilderBase || value instanceof KnexRaw) {
+    if (value instanceof KnexQueryBuilder || value instanceof QueryBuilderBase || value instanceof KnexRaw || value instanceof ReferenceBuilder) {
       needsSplit = true;
       break;
     }
@@ -36,7 +38,7 @@ function split(obj) {
     const key = keys[i];
     const value = obj[key];
 
-    if (value instanceof KnexQueryBuilder || value instanceof KnexRaw) {
+    if (value instanceof KnexQueryBuilder || value instanceof KnexRaw || value instanceof ReferenceBuilder) {
       ret.query[key] = value;
     } else if (value instanceof QueryBuilderBase) {
       ret.query[key] = value.build();

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -235,7 +235,21 @@ module.exports = function (session) {
       });
     });
 
-    describe.skip('.update()', function () {
+    describe('.update()', function () {
+      before(function () {
+        return BoundModel
+          .query()
+          .truncate()
+          .then(function () {
+            return BoundModel.query().insert([
+              {name: "test1", jsonObject: {}, jsonArray: [ 1 ]},
+              {name: "test2", jsonObject: { attr: 2 }, jsonArray: [ 2 ]},
+              {name: "test3", jsonObject: { attr: 3 }, jsonArray: [ 3 ]},
+              {name: "test4", jsonObject: { attr: 4 }, jsonArray: [ 4 ]},
+            ]);
+          });
+      });
+
       it('should update nicely', function () {
         let SchemalessBoundModel = Model.bindKnex(session.knex);
 
@@ -252,12 +266,17 @@ module.exports = function (session) {
             // each attribute which is updated with ref must be updated separately
             // e.g. SET "jsonArray" = '[ ref(...), ref(...) ]' just isn't valid SQL
             // (though it could be kind of parsed to multiple jsonb_set calls which would be insanely cool)
-            jsonArray: ref('name')
+            jsonArray: ref('name').castJson()
           })
           .where('id', 1) // something something
-          .return('*')
+          .returning('*')
           .then(function (result) {
-            console.log("Got data.. check when implemented", result);
+            expect(result).to.eql([{
+              id: 1,
+              name: '1',
+              jsonObject: { attr: 'test1' },
+              jsonArray: 'test1' }
+            ]);
           });
       });
     });
@@ -272,6 +291,7 @@ module.exports = function (session) {
             jsonArray: ref('name')
           })
           .where('id', 1)
+          .returning('*')
           .then(function (result) {
             console.log("Got data.. check when implemented", result);
           });

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -85,7 +85,7 @@ module.exports = function (session) {
           });
       });
 
-      it.skip('should be able to use ref inside select of select subquery', function () {
+      it('should be able to use ref inside select of select subquery', function () {
         return BoundModel.query()
           .select([
             function (builder) {

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -225,7 +225,7 @@ module.exports = function (session) {
       it('should insert nicely', function () {
         // this query actually isnt valid, but I couldn't figure any query where one would actually use ref as value
         // so just testing that refs are converted to raw correctly
-        let query = BoundModel.query()
+        var query = BoundModel.query()
           .insert({
             name: ref('jsonArray:[0]').castText(),
             jsonObject: ref('name').castJson(),
@@ -254,7 +254,7 @@ module.exports = function (session) {
         return BoundModel.query()
           .update({
             jsonArray: BoundModel.knex().raw('to_jsonb(??)', ['name'])
-          }).then(result => {
+          }).then(function (result) {
             expect(result).to.be(4);
           });
       });

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var expect = require('expect.js');
 var Promise = require('bluebird');
 var Model = require('../../').Model;
+var ref = require('../../').ref;
 
 function expectIdsEqual(resultArray, expectedIds) {
   expectArraysEqual(_(resultArray).map('id').sort().value(), expectedIds);
@@ -32,6 +33,8 @@ module.exports = function (session) {
     }
   };
 
+  var BoundModel = ModelJson.bindKnex(session.knex);
+
   before(function () {
     return session.knex.schema
       .dropTableIfExists('ModelJson')
@@ -43,7 +46,227 @@ module.exports = function (session) {
       });
   });
 
-  var BoundModel = ModelJson.bindKnex(session.knex);
+  describe('QueryBuilder using ref() in normal query builder methods', function () {
+    describe('Querying rows', function () {
+      before(function () {
+        return BoundModel
+          .query()
+          .delete()
+          .then(function () {
+            return BoundModel.query().insert([
+              {name: "test1", jsonObject: {}, jsonArray: [ 1 ]},
+              {name: "test2", jsonObject: { attr: 2 }, jsonArray: [ 2 ]},
+              {name: "test3", jsonObject: { attr: 3 }, jsonArray: [ 3 ]},
+              {name: "test4", jsonObject: { attr: 4 }, jsonArray: [ 4 ]},
+            ]);
+        });
+      });
+
+      it('should be able to extract json attr in select(ref)', function () {
+        return BoundModel.query()
+          .select(ref('jsonArray:[0]').as('foo'))
+          .orderBy('foo')
+          .then(function (result) {
+            expect(result).to.have.length(4);
+            expect(_.first(result)).eql({ foo: 1 });
+          });
+      });
+
+      it('should be able to extract json attr in select(array)', function () {
+        return BoundModel.query()
+          .select([
+            ref('jsonObject:attr').castBigInt().as('bar'),
+            ref('jsonArray:[0]').as('foo')
+          ])
+          .orderBy('foo')
+          .then(function (result) {
+            expect(result).to.have.length(4);
+            expect(_.first(result)).eql({ foo: 1, bar: null });
+          });
+      });
+
+      it.skip('should be able to use ref inside select of select subquery', function () {
+        return BoundModel.query()
+          .select([
+            function (builder) {
+              builder.select([
+                ref('name').as('barName')
+              ])
+              .from('ModelJson')
+              .orderBy('name')
+              .limit(1).as('foo');
+            },
+            ref('jsonArray:[0]').as('firstArrayItem')
+          ])
+          .orderBy('firstArrayItem', 'desc')
+          .then(function (result) {
+            console.log("Got data", result);
+            expect(result).to.have.length(4);
+            // foo is always name of the first row of the table (pretty nonsense query)
+            expect(_.first(result)).eql({ foo: 'test1', firstArrayItem: 4 });
+          });
+      });
+
+      it('should be able to use ref with where', function () {
+        return BoundModel.query()
+          .where(
+            ref('jsonArray:[0]').castBigInt(),
+            ref('jsonObject:attr').castBigInt()
+          )
+          .then(function (result) {
+            expect(result).to.have.length(3);
+          });
+      });
+
+      it('should be able to use ref with where subquery', function () {
+        return BoundModel.query()
+          .where(function (builder) {
+            builder.where(
+              ref('jsonArray:[0]').castBigInt(),
+              ref('jsonObject:attr').castBigInt()
+            );
+          })
+          .then(function (result) {
+            expect(result).to.have.length(3);
+          });
+      });
+
+      it('should be able to use ref with join', function () {
+        // select * from foo join bar on ref() = ref()
+        return BoundModel.query()
+          .join(
+            'ModelJson as t2',
+            ref('ModelJson.jsonArray:[0]'), '=', ref('t2.jsonObject:attr')
+          )
+          .select('t2.*')
+          .then(function (result) {
+            expect(result).to.have.length(3);
+          });
+      });
+
+      it.skip('should be able to use ref with double nested join builder', function () {
+        // select * from foo join bar on ref() = ref()
+        return BoundModel.query()
+          .join('ModelJson as t2', function (builder) {
+            builder
+              .on(ref('ModelJson.jsonArray:[0]'), '=', ref('t2.jsonObject:attr'))
+              .on(function (nestedBuilder) {
+                nestedBuilder
+                  .on(
+                    ref('ModelJson.id').castInt(), '=',
+                    ref('t2.jsonArray:[0]').castInt()
+                  )
+                  .orOn(
+                    ref('ModelJson.id').castInt(), '=',
+                    ref('t2.jsonObject:attr').castInt()
+                  );
+              });
+          })
+          .select('t2.*')
+          .then(function (result) {
+            console.log("Got data, check the result when implemented", result);
+          });
+      });
+
+      it('should be able to use ref with orderBy', function () {
+        return BoundModel.query().orderBy(ref('jsonObject:attr'), 'desc')
+          .then(function (result) {
+            expect(result).to.have.length(4);
+            // null is first
+            expect(_.first(result).name).to.equal('test1');
+          });
+      });
+
+      it.skip('should be able to use ref with groupBy and having', function () {
+        return BoundModel.query()
+          .select(['id', ref('jsonObject:attr').as('foo')])
+          .groupBy([ref('jsonObject:attr'), 'id'])
+          .having(ref('id').castInt(), '>=', ref('jsonObject:attr').castInt())
+          .orderBy('foo')
+          .then(function (result) {
+            expect(result).to.have.length(3);
+            expect(_.first(result)).to.eql({ id: 2, foo: 2 });
+          });
+      });
+
+      it.skip('should be able to use ref with groupBy and nested having', function () {
+        return BoundModel.query()
+          .select(['id', ref('jsonObject:attr').as('foo')])
+          .groupBy([ref('jsonObject:attr'), 'id'])
+          .having(ref('id').castInt(), '>=', ref('jsonObject:attr').castInt())
+          // knex doesnt seem to support nested having
+          .having(function (builder) {
+            builder
+              .having(ref('id'), '=', ref('id'))
+              .having(function (nestedBuilder) {
+                nestedBuilder.having(ref('id'), '=', ref('id'));
+              });
+          })
+          .orderBy('foo')
+          .then(function (result) {
+            expect(result).to.have.length(3);
+            expect(_.first(result)).to.eql({ id: 2, foo: 2 });
+          });
+      });
+    });
+
+    describe.skip('.insert()', function () {
+      it('should insert nicely', function () {
+        // this query actually isnt valid, but I couldn't figure any query where one would actually use ref as value
+        // so just testing that refs are converted to raw correctly
+        let query = BoundModel.query()
+          .insert({
+            name: ref('jsonArray:[0]').castText(),
+            jsonObject: ref('name').castJson(),
+            jsonArray: [ 1 ]
+          });
+        // I have no idea how to check built result.. toSql() didn't seem to help in this case
+      });
+    });
+
+    describe.skip('.update()', function () {
+      it('should update nicely', function () {
+        let SchemalessBoundModel = Model.bindKnex(session.knex);
+
+        // should do something like:
+        // update "ModelJson" set
+        //   "jsonArray" = jsonb_set('[]', '{0}', to_jsonb("name"), true),
+        //   "jsonObject" = jsonb_set("jsonObject", '{attr}', to_jsonb("name"), true),
+        //   "name" = "jsonArray"#>>'{0}' where "id" = 1 returning *;
+        return SchemalessBoundModel.query()
+          .table('ModelJson')
+          .update({
+            name: ref('jsonArray:[0]').castText(),
+            'jsonObject:attr': ref('name'),
+            // each attribute which is updated with ref must be updated separately
+            // e.g. SET "jsonArray" = '[ ref(...), ref(...) ]' just isn't valid SQL
+            // (though it could be kind of parsed to multiple jsonb_set calls which would be insanely cool)
+            jsonArray: ref('name')
+          })
+          .where('id', 1) // something something
+          .return('*')
+          .then(function (result) {
+            console.log("Got data.. check when implemented", result);
+          });
+      });
+    });
+
+    describe.skip('.patch()', function () {
+      it('should patch nicely', function () {
+        // same stuff that with patch but different api method
+        return BoundModel.query()
+          .patch({
+            name: ref('jsonArray:[0]').castText(),
+            'jsonObject:attr': ref('name'),
+            jsonArray: ref('name')
+          })
+          .where('id', 1)
+          .then(function (result) {
+            console.log("Got data.. check when implemented", result);
+          });
+      });
+    });
+  });
 
   describe('QueryBuilder JSON queries', function () {
     var complexJsonObj;

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -205,7 +205,6 @@ module.exports = function (session) {
           .select(['id', ref('jsonObject:attr').as('foo')])
           .groupBy([ref('jsonObject:attr'), 'id'])
           .having('id', '>=', ref('jsonObject:attr').castInt())
-          // knex doesnt seem to support nested having
           .having(function (builder) {
             builder
               .having('id', '=', ref('id'))
@@ -259,7 +258,7 @@ module.exports = function (session) {
           });
       });
 
-      it('should update nicely', function () {
+      it('should be able to update internal field of json column and allow ref() syntax', function () {
         // should do something like:
         // update "ModelJson" set
         //   "jsonArray" = jsonb_set('[]', '{0}', to_jsonb("name"), true),
@@ -286,7 +285,7 @@ module.exports = function (session) {
           });
       });
 
-      it('should patch nicely', function () {
+      it('should be able to patch internal field of json column and allow ref() syntax', function () {
         // same stuff that with patch but different api method
         return BoundModel.query()
           .patch({

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -100,9 +100,8 @@ module.exports = function (session) {
           ])
           .orderBy('firstArrayItem', 'desc')
           .then(function (result) {
-            console.log("Got data", result);
             expect(result).to.have.length(4);
-            // foo is always name of the first row of the table (pretty nonsense query)
+            // foo is always name of the first row of the table (quite a nonsense query)
             expect(_.first(result)).eql({ foo: 'test1', firstArrayItem: 4 });
           });
       });
@@ -144,8 +143,7 @@ module.exports = function (session) {
           });
       });
 
-      it.skip('should be able to use ref with double nested join builder', function () {
-        // select * from foo join bar on ref() = ref()
+      it('should be able to use ref with double nested join builder', function () {
         return BoundModel.query()
           .join('ModelJson as t2', function (builder) {
             builder
@@ -164,7 +162,7 @@ module.exports = function (session) {
           })
           .select('t2.*')
           .then(function (result) {
-            console.log("Got data, check the result when implemented", result);
+            expect(result).to.have.length(3);
           });
       });
 

--- a/tests/integration/jsonQueries.js
+++ b/tests/integration/jsonQueries.js
@@ -175,10 +175,23 @@ module.exports = function (session) {
           });
       });
 
-      it.skip('should be able to use ref with groupBy and having', function () {
+      it('should be able to use ref with groupBy and having (last argument of having is ref)', function () {
         return BoundModel.query()
           .select(['id', ref('jsonObject:attr').as('foo')])
           .groupBy([ref('jsonObject:attr'), 'id'])
+          .having('id', '>=', ref('jsonObject:attr').castInt())
+          .orderBy('foo')
+          .then(function (result) {
+            expect(result).to.have.length(3);
+            expect(_.first(result)).to.eql({ id: 2, foo: 2 });
+          });
+      });
+
+      it.skip('should be able to use ref with groupBy and having (also first arg is ref)', function () {
+        return BoundModel.query()
+          .select(['id', ref('jsonObject:attr').as('foo')])
+          .groupBy([ref('jsonObject:attr'), 'id'])
+          // knex doesn't support knex raw as first arg here so this test fails....
           .having(ref('id').castInt(), '>=', ref('jsonObject:attr').castInt())
           .orderBy('foo')
           .then(function (result) {
@@ -187,17 +200,17 @@ module.exports = function (session) {
           });
       });
 
-      it.skip('should be able to use ref with groupBy and nested having', function () {
+      it('should be able to use ref with groupBy and nested having', function () {
         return BoundModel.query()
           .select(['id', ref('jsonObject:attr').as('foo')])
           .groupBy([ref('jsonObject:attr'), 'id'])
-          .having(ref('id').castInt(), '>=', ref('jsonObject:attr').castInt())
+          .having('id', '>=', ref('jsonObject:attr').castInt())
           // knex doesnt seem to support nested having
           .having(function (builder) {
             builder
-              .having(ref('id'), '=', ref('id'))
+              .having('id', '=', ref('id'))
               .having(function (nestedBuilder) {
-                nestedBuilder.having(ref('id'), '=', ref('id'));
+                nestedBuilder.having('id', '=', ref('id'));
               });
           })
           .orderBy('foo')

--- a/tests/unit/queryBuilder/ReferenceBuilder.js
+++ b/tests/unit/queryBuilder/ReferenceBuilder.js
@@ -17,12 +17,12 @@ describe('ReferenceBuilder', function () {
   });
 
   it('should allow plain knex reference + casting', function () {
-    let reference = ref('Table.Column').asBigInt();
+    let reference = ref('Table.Column').castBigInt();
     expect(reference.toRawArgs()).to.eql(['CAST(?? AS bigint)', ['Table.Column']]);
   });
 
   it('should allow field expression + casting', function () {
-    let reference = ref('Table.Column:jsonAttr').asBool();
+    let reference = ref('Table.Column:jsonAttr').castBool();
     expect(reference.toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
   });
 
@@ -32,13 +32,13 @@ describe('ReferenceBuilder', function () {
   });
 
   it('should support few different casts', function () {
-    expect(ref('Table.Column:jsonAttr').asText().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS text)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS integer)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asBigInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS bigint)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asFloat().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS float)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asDecimal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS decimal)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asReal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS real)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asBool().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').asJsonb().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS jsonb)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castText().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS text)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS integer)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castBigInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS bigint)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castFloat().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS float)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castDecimal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS decimal)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castReal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS real)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castBool().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
+    expect(ref('Table.Column').castJson().toRawArgs()).to.eql([`to_jsonb(??)`, ['Table.Column']]);
   });
 });

--- a/tests/unit/queryBuilder/ReferenceBuilder.js
+++ b/tests/unit/queryBuilder/ReferenceBuilder.js
@@ -11,34 +11,34 @@ describe('ReferenceBuilder', function () {
   });
 
   it('should create ReferenceBuilder', function () {
-    let reference = ref('Awwww.ItWorks');
+    var reference = ref('Awwww.ItWorks');
     expect(reference instanceof ReferenceBuilder).to.be.ok();
     expect(reference.toRawArgs()).to.eql(['??', ['Awwww.ItWorks']]);
   });
 
   it('should allow plain knex reference + casting', function () {
-    let reference = ref('Table.Column').castBigInt();
+    var reference = ref('Table.Column').castBigInt();
     expect(reference.toRawArgs()).to.eql(['CAST(?? AS bigint)', ['Table.Column']]);
   });
 
   it('should allow field expression + casting', function () {
-    let reference = ref('Table.Column:jsonAttr').castBool();
-    expect(reference.toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
+    var reference = ref('Table.Column:jsonAttr').castBool();
+    expect(reference.toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS boolean)", ['Table.Column']]);
   });
 
   it('should allow field expression + no casting', function () {
-    let reference = ref('Table.Column:jsonAttr');
-    expect(reference.toRawArgs()).to.eql([`??#>'{jsonAttr}'`, ['Table.Column']]);
+    var reference = ref('Table.Column:jsonAttr');
+    expect(reference.toRawArgs()).to.eql(["??#>'{jsonAttr}'", ['Table.Column']]);
   });
 
   it('should support few different casts', function () {
-    expect(ref('Table.Column:jsonAttr').castText().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS text)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS integer)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castBigInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS bigint)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castFloat().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS float)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castDecimal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS decimal)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castReal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS real)`, ['Table.Column']]);
-    expect(ref('Table.Column:jsonAttr').castBool().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
-    expect(ref('Table.Column').castJson().toRawArgs()).to.eql([`to_jsonb(??)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castText().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS text)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castInt().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS integer)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castBigInt().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS bigint)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castFloat().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS float)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castDecimal().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS decimal)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castReal().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS real)", ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').castBool().toRawArgs()).to.eql(["CAST(??#>>'{jsonAttr}' AS boolean)", ['Table.Column']]);
+    expect(ref('Table.Column').castJson().toRawArgs()).to.eql(["to_jsonb(??)", ['Table.Column']]);
   });
 });

--- a/tests/unit/queryBuilder/ReferenceBuilder.js
+++ b/tests/unit/queryBuilder/ReferenceBuilder.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var expect = require('expect.js')
+  , ref = require('../../../').ref
+  , ReferenceBuilder = require('../../../lib/queryBuilder/ReferenceBuilder').default;
+
+describe('ReferenceBuilder', function () {
+  it('fail if reference cannot be parsed', function () {
+    expect(function () { ref(); }).to.throwException();
+    expect(function () { ref(''); }).to.throwException();
+  });
+
+  it('should create ReferenceBuilder', function () {
+    let reference = ref('Awwww.ItWorks');
+    expect(reference instanceof ReferenceBuilder).to.be.ok();
+    expect(reference.toRawArgs()).to.eql(['??', ['Awwww.ItWorks']]);
+  });
+
+  it('should allow plain knex reference + casting', function () {
+    let reference = ref('Table.Column').asBigInt();
+    expect(reference.toRawArgs()).to.eql(['CAST(?? AS bigint)', ['Table.Column']]);
+  });
+
+  it('should allow field expression + casting', function () {
+    let reference = ref('Table.Column:jsonAttr').asBool();
+    expect(reference.toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
+  });
+
+  it('should allow field expression + no casting', function () {
+    let reference = ref('Table.Column:jsonAttr');
+    expect(reference.toRawArgs()).to.eql([`??#>'{jsonAttr}'`, ['Table.Column']]);
+  });
+
+  it('should support few different casts', function () {
+    expect(ref('Table.Column:jsonAttr').asText().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS text)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS integer)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asBigInt().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS bigint)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asFloat().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS float)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asDecimal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS decimal)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asReal().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS real)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asBool().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS boolean)`, ['Table.Column']]);
+    expect(ref('Table.Column:jsonAttr').asJsonb().toRawArgs()).to.eql([`CAST(??#>>'{jsonAttr}' AS jsonb)`, ['Table.Column']]);
+  });
+});


### PR DESCRIPTION
Adds support to easy places to be able to use ref syntax instead of knex.raw... check test cases which parts are now supported.

Stuff that should be done nicer and implemented later on: 

* Documentation!!
* JoinBuilder is currently inherited from BaseQueryBuilder so there are way too many methods available
* Typings at least for ReferenceBuilder
* Add also shorthand wrappers for lit (literals with casting info and e.g. which sql-array/list syntax certain passed array value is) and raw (convenience wrapper for knex.raw, which will be converted to knex.raw by objection APIs like ref)
* Implementations for mysql and sqlite json syntax
