### PR TITLE
Fix when creating ManyToManyRelation

### DIFF
--- a/src/queryBuilder/graphInserter/GraphInserter.js
+++ b/src/queryBuilder/graphInserter/GraphInserter.js
@@ -209,7 +209,7 @@ export default class GraphInserter {
       const tableInsertion = batch[modelName];
 
       if (tableInsertion.models.length) {
-        const keys = _.keys(tableInsertion.models[0]);
+        const keys = _.uniq(_.flatMap(tableInsertion.models, _.keys));
 
         tableInsertion.models = _.uniqBy(tableInsertion.models, model => model.$propKey(keys));
         tableInsertion.isInputModel = _.times(tableInsertion.models.length, _.constant(false));


### PR DESCRIPTION
This should fix problem when inserting multiple relations into same table.
E.g. table: (orgId, locationId, channelId, userId) with data [{orgId, locationId}, {orgId, channelId}, {orgId, userId}], previously it would pulled keys only from first object/model which would cause `$propKey` function to filter out all other objects.