### PR TITLE
Update Insert type definition to return a model instance

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -298,9 +298,9 @@ declare module "objection" {
    */
   export interface QueryBuilder<T> extends QueryBuilderBase<T>, Promise<T[]> { }
 
-  interface Insert {
-    <M extends ModelOrObject>(modelOrObject?: M): QueryBuilderSingle<M>;
-    <M extends ModelsOrObjects>(modelsOrObjects?: M): QueryBuilder<M>;
+  interface Insert<T> {
+    <M extends ModelOrObject>(modelOrObject?: M): QueryBuilderSingle<T>;
+    <M extends ModelsOrObjects>(modelsOrObjects?: M): QueryBuilder<T>;
     (): this;
   }
 
@@ -315,17 +315,17 @@ declare module "objection" {
     findById(id: Id): QueryBuilderOption<T>;
     findById(idOrIds: IdOrIds): this;
 
-    insert: Insert;
+    insert: Insert<T>;
     insertAndFetch(modelOrObject: ModelOrObject): QueryBuilderSingle<T>;
     insertAndFetch(modelsOrObjects?: ModelsOrObjects): QueryBuilder<T>;
 
-    insertGraph: Insert;
+    insertGraph: Insert<T>;
     insertGraphAndFetch: InsertGraphAndFetch<T>
 
     /**
      * insertWithRelated is an alias for insertGraph.
      */
-    insertWithRelated: Insert;
+    insertWithRelated: Insert<T>;
     insertWithRelatedAndFetch: InsertGraphAndFetch<T>
 
     /**


### PR DESCRIPTION
Since it accepts an object but returns an instance of the Model. This is helpful in cases where we strictly define the properties of the instance but, allow creating the instance without some of this values. e.g.:

```ts
const accountInstance = await Account.query().insert({
    name: "Pepe"
});
await accountInstance.instanceMethod();
```

This example will throw in typescript since the instanceMethod is not part of the passed object, but after the patch, it works, else i would have to use insertAndFetch to be able to call the instance methods.

It would also be nice to have support for installing this type definition using  `@typings/objection`

http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html


