### PR TITLE
Upgrade to TS2.2 and fix Insert typing

### DIFF
--- a/examples/express-ts/package.json
+++ b/examples/express-ts/package.json
@@ -14,23 +14,23 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.15.1",
-    "express": "^4.13.4",
-    "knex": "^0.10.0",
-    "lodash": "^4.12.0",
-    "morgan": "^1.7.0",
+    "body-parser": "^1.16.1",
+    "express": "^4.14.1",
+    "knex": "^0.12.7",
+    "lodash": "^4.17.4",
+    "morgan": "^1.8.1",
     "objection": "../..",
-    "sqlite3": "^3.1.3"
+    "sqlite3": "^3.1.8"
   },
   "devDependencies": {
-    "@types/body-parser": "0.0.33",
-    "@types/express": "^4.0.33",
-    "@types/knex": "0.0.35",
-    "@types/lodash": "^4.14.38",
+    "@types/body-parser": "^0.0.34",
+    "@types/express": "^4.0.35",
+    "@types/knex": "^0.0.41",
+    "@types/lodash": "^4.14.53",
     "@types/morgan": "^1.7.32",
-    "@types/sqlite3": "^2.2.31",
-    "tslint": "^4.0.2",
-    "tslint-config-standard": "^2.0.0",
-    "typescript": "=2.0.10"
+    "@types/sqlite3": "^2.2.32",
+    "tslint": "^4.4.2",
+    "tslint-config-standard": "^4.0.0",
+    "typescript": "^2.2.1"
   }
 }

--- a/examples/express-ts/src/repl.js
+++ b/examples/express-ts/src/repl.js
@@ -1,0 +1,27 @@
+const Knex = require("knex");
+const objection = require("objection");
+const knexConfig = require('../knexfile');
+const knex = Knex(knexConfig.development);
+objection.Model.knex(knex);
+knex.migrate.latest().then(() => console.log("Migrated."))
+
+// wait
+
+const Person = require("./lib/models/Person").default
+
+Person.query().insertGraph({
+  firstName: "Testy",
+  lastName: "McTesterson",
+  pets: [{
+    name: "Fluffy McTesterson"
+  }]
+}).then((result) => {
+  console.log("InsertGraph done:")
+  console.dir(result)
+})
+
+Person.query().where('firstName', "Testy").then((result) => {
+  console.log("where found:")
+  console.dir(result)
+})
+

--- a/examples/express-ts/tsconfig.json
+++ b/examples/express-ts/tsconfig.json
@@ -13,10 +13,9 @@
     "strictNullChecks": true,
     "target": "es6",
     "rootDir": "src",
-    "outDir": "lib",
-    "typeRoots": [
-      "./typings",
-      "node_modules/@types"
-    ]
-  }
+    "outDir": "lib"
+  },
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "pg": "^6.1.2",
     "source-map-support": "^0.4.3",
     "sqlite3": "^3.0.8",
-    "typescript": "2.1.5"
+    "typescript": "^2.2.1"
   }
 }

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -145,7 +145,7 @@ qb = qb.joinRelation('table', { alias: false });
 
 const rowInserted: Promise<Person> = qb.insert({firstName: "bob"})
 const rowsInserted: Promise<Person[]> = qb.insert([{firstName: "alice"}, {firstName: "bob"}])
-const rowsInsertedWithRelated: Promise<number> = qb.insertWithRelated({})
+const rowsInsertedWithRelated: Promise<Person> = qb.insertWithRelated({})
 const rowsUpdated: Promise<number> = qb.update({})
 const rowsPatched: Promise<number> = qb.patch({})
 const rowsDeleted: Promise<number> = qb.deleteById(123)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitThis": true,
     "noImplicitUseStrict": false,
     "strictNullChecks": true,
+    "experimentalDecorators": true,
     "noEmit": true,
     "target": "es6",
     "typeRoots": [

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -302,8 +302,8 @@ declare module "objection" {
   export interface QueryBuilder<T> extends QueryBuilderBase<T>, Promise<T[]> { }
 
   interface Insert<T> {
+    <M extends Model[] | Object[]>(modelsOrObjects?: M): QueryBuilder<T>;
     <M extends ModelOrObject>(modelOrObject?: M): QueryBuilderSingle<T>;
-    <M extends ModelsOrObjects>(modelsOrObjects?: M): QueryBuilder<T>;
     (): this;
   }
 


### PR DESCRIPTION
`Insert<T>` used `ModelsOrObjects`, which includes `ModelOrObject`. 

The new, (better) typescript parser found this issue that caused `insert([])` to now return singular values. I changed the plural result matcher to be `Object[] | Model[]` before matching on Object (which matches arrays).

I updated all other packages as well in the example project (and wrote a simple repl.js to ensure this was all behaving well in the node REPL).