### PR TITLE
Update ValidationError typedef to be class

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -14,9 +14,11 @@ declare module "objection" {
     skipValidation: boolean;
   }
 
-  export interface ValidationError {
+  export class ValidationError extends Error {
+    constructor(errors: any);
     statusCode: number;
     data: any;
+    message: string;
   }
 
   export type RelationMappings = { [relationName: string]: RelationMapping };


### PR DESCRIPTION
ValidationError is currently defined in index.d.ts as an interface.
However, typescript interfaces are not runtime constructs, so it is
impossible to make calls like: `if (err instanceof ValidationError)`.

In ValidationError.js, ValidationError is defined as a class that
extends Error, so update the type definition accordingly.