### PR TITLE
Improve `extend`, `$relatedQuery`, and `.transaction` typings

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -18,11 +18,11 @@ class Person extends objection.Model {
   }
 
   static async withLastName(lastName: string): Promise<Person[]> {
-    return this.query().where("lastName", lastName)
+    return this.query().where('lastName', lastName)
   }
 
   static async firstWithLastName(lastName: string): Promise<Person | undefined> {
-    return this.query().where("lastName", lastName).first()
+    return this.query().where('lastName', lastName).first()
   }
 
   static async findById(id: number): Promise<Person | undefined> {
@@ -30,7 +30,7 @@ class Person extends objection.Model {
   }
 
   async loadMovies(): Promise<this> {
-    return this.$loadRelated("movies")
+    return this.$loadRelated('movies')
   }
 
   async reload(): Promise<this> {
@@ -39,7 +39,7 @@ class Person extends objection.Model {
 
   async petsWithId(petId: number): Promise<Animal[]> {
     // Types can't look at strings and give strong types, so this must be a Model[] promise:
-    const pets: objection.Model[] = await this.$relatedQuery('pets').where("id", petId)
+    const pets: objection.Model[] = await this.$relatedQuery('pets').where('id', petId)
     // that we can subsequently cast to Animal:
     return pets as Animal[]
   }
@@ -94,7 +94,7 @@ const clonePerson: Person = examplePerson.$clone();
 
 // static methods from Model should return the subclass type
 
-Person.loadRelated([new Person()], "movies").then((people: Person[]) => { });
+Person.loadRelated([new Person()], 'movies').then((people: Person[]) => { });
 
 class Actor {
   canAct: boolean
@@ -104,7 +104,7 @@ class Actor {
 const PersonActor = Person.extend(Actor);
 
 const pa = new PersonActor()
-pa.firstName = "chuck"
+pa.firstName = 'chuck'
 pa.canAct = false
 
 // Optional<Person> typing for findById():
@@ -123,7 +123,7 @@ const personPromise: Promise<Person> = objection.QueryBuilder.forClass(Person).f
 
 // QueryBuilder.findById accepts single and array values:
 
-let qb: objection.QueryBuilder<Person> = BoundPerson.query().where("name", "foo");
+let qb: objection.QueryBuilder<Person> = BoundPerson.query().where('name', 'foo');
 
 // Note that the QueryBuilder chaining done in this file
 // is done to verify that the return value is assignable to a QueryBuilder
@@ -153,8 +153,8 @@ qb = qb.joinRelation('table', { alias: false });
 
 // signature-changing QueryBuilder methods:
 
-const rowInserted: Promise<Person> = qb.insert({ firstName: "bob" })
-const rowsInserted: Promise<Person[]> = qb.insert([{ firstName: "alice" }, { firstName: "bob" }])
+const rowInserted: Promise<Person> = qb.insert({ firstName: 'bob' })
+const rowsInserted: Promise<Person[]> = qb.insert([{ firstName: 'alice' }, { firstName: 'bob' }])
 const rowsInsertedWithRelated: Promise<Person> = qb.insertWithRelated({})
 const rowsUpdated: Promise<number> = qb.update({})
 const rowsPatched: Promise<number> = qb.patch({})
@@ -252,12 +252,26 @@ const p: Promise<string> = qb.then(() => 'done');
 
 // Verify that we can insert a partial model and relate a partial movie
 Person.query()
-  .insertAndFetch({ firstName: "Jim" } as Partial<Person>)
+  .insertAndFetch({ firstName: 'Jim' })
   .then((p: Person) => {
     console.log(`Inserted ${p}`);
     p.$loadRelated('movies')
-      .relate({ title: 'Total Recall' } as Partial<Movie>)
+      .relate<Movie>({ title: 'Total Recall' })
       .then((pWithMovie: Person) => {
         console.log(`Related ${pWithMovie}`);
       });
   });
+
+// Verify we can call `.insert` with a Partial<Person>:
+
+Person
+  .query()
+  .insert({ firstName: 'Chuck' })
+
+// Verify we can call `.insert` via $relatedQuery 
+// (albeit with a cast to Movie):
+
+new Person()
+  .$relatedQuery<Movie>('movies')
+  .insert({ title: 'Total Recall' })
+

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -221,7 +221,12 @@ declare module "objection" {
 
     static bindKnex<T>(this: T, knex: knex): T;
     static bindTransaction<T>(this: T, transaction: Transaction): T;
-    static extend<S, T>(this: T, subclass: S): S & T;
+
+    // TODO: It'd be nicer to expose an actual T&S union class here: 
+    static extend<T extends Model, S>(
+      this: { new (): T },
+      subclass: { new (): S }
+    ): ModelClass<T> & { new (...args: any[]): T & S };
 
     static fromJson<T>(this: T, json: Object, opt?: ModelOptions): T;
     static fromDatabaseJson<T>(this: T, row: Object): T;
@@ -510,6 +515,15 @@ declare module "objection" {
       modelClass3: MC3,
       modelClass4: MC4,
       callback: (boundModel1Class: MC1, boundModel2Class: MC2, boundModel3Class: MC3, boundModel4Class: MC4) => Promise<T>
+    ): Promise<T>;
+
+    <MC1 extends ModelClass<any>, MC2 extends ModelClass<any>, MC3 extends ModelClass<any>, MC4 extends ModelClass<any>, MC5 extends ModelClass<any>, T>(
+      modelClass1: MC1,
+      modelClass2: MC2,
+      modelClass3: MC3,
+      modelClass4: MC4,
+      modelClass5: MC5,
+      callback: (boundModel1Class: MC1, boundModel2Class: MC2, boundModel3Class: MC3, boundModel4Class: MC4, boundModel5Class: MC5) => Promise<T>
     ): Promise<T>;
 
   }

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -223,10 +223,10 @@ declare module "objection" {
     static bindTransaction<T>(this: T, transaction: Transaction): T;
 
     // TODO: It'd be nicer to expose an actual T&S union class here: 
-    static extend<T extends Model, S>(
-      this: { new (): T },
+    static extend<M extends Model, S>(
+      this: { new (): M },
       subclass: { new (): S }
-    ): ModelClass<T> & { new (...args: any[]): T & S };
+    ): ModelClass<M> & { new (...args: any[]): M & S };
 
     static fromJson<T>(this: T, json: Object, opt?: ModelOptions): T;
     static fromDatabaseJson<T>(this: T, row: Object): T;
@@ -266,9 +266,11 @@ declare module "objection" {
     $query(trx?: Transaction): QueryBuilderSingle<this>;
 
     /**
-     * @return `QueryBuilder<Model>` because we don't know the type of the relation.
+     * Users need to explicitly type these calls, as the relationName doesn't
+     * indicate the type (and if it returned Model directly, Partial<Model>
+     * guards are worthless)
      */
-    $relatedQuery(relationName: string, transaction?: Transaction): QueryBuilder<Model>;
+    $relatedQuery<M extends Model>(relationName: string, transaction?: Transaction): QueryBuilder<M>;
 
     $loadRelated<T>(expression: RelationExpression, filters?: Filters<T>): QueryBuilderSingle<this>;
 
@@ -286,7 +288,7 @@ declare module "objection" {
 
   export class QueryBuilder<T> {
     static extend(subclassConstructor: FunctionConstructor): void;
-    static forClass<T extends Model>(modelClass: ModelClass<T>): QueryBuilder<T>;
+    static forClass<M extends Model>(modelClass: ModelClass<M>): QueryBuilder<M>;
   }
 
   /**


### PR DESCRIPTION
Functionality:
* Updated `extend` (and example) to work properly with TS 2.2
* Updated `$relatedQuery` to take a generic Model subclass, so chained `Partial`s would work properly
* Updated `.transaction` to take 5 model classes (yes, I actually am using 5 directly related classes in my own code now)
* Updated `examples.ts` to exercise the new generic types

Linting:
* delinted `examples.ts` to use consistent quotation marks
* made `index.d.ts` generics use "M" consistently for `Model` subtypes

(Local testing done with TypeScript 2.2.1)