### PR TITLE
Support passing in attributes on model constructor

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -126,6 +126,10 @@ export default class Model {
    */
   static defaultEagerOptions = null;
 
+  constructor(json, opts) {
+    this.$setJson(json || {}, opts);
+  }
+
   /**
    * @param {*=} id
    * @returns {*}
@@ -686,9 +690,7 @@ export default class Model {
    * @throws ValidationError
    */
   static fromJson(json, options) {
-    let model = new this();
-    model.$setJson(json || {}, options);
-    return model;
+    return new this(json, options);
   }
 
   /**


### PR DESCRIPTION
This patch changes the Model constructor to support the same options `fromJson` does. I'd like this functionality as there are some handy utilities out there that you can use with ORMs, but they sometimes expect the constructor to accept an object representing desired attributes as it's first parameter.

I wasn't sure how you'd want to handle updating the unit tests for this; didn't think it would have been appropriate to duplicate the entire block of tests for fromJson.