### PR TITLE
Adding more Postgres "returning" tricks for "delete".

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -266,7 +266,7 @@ the Promise is rejected with a [`ValidationError`](#validationerror).
 NOTE: The return value of the insert query _only_ contains the properties given to the insert
 method plus the identifier. This is because we don't make an additional fetch query after
 the insert. Using postgres you can chain [`returning('*')`](#returning) to the query to get all
-properties - see [this recipe](#postgresql-returning-tricks) for some examples. On other databases you
+properties - see [this recipe](#postgresql-quot-returning-quot-tricks) for some examples. On other databases you
 can use the [`insertAndFetch`](#insertandfetch) method.
 
 The batch insert only works on Postgres because Postgres is the only database engine
@@ -299,7 +299,7 @@ var builder = queryBuilder.insertAndFetch(modelsOrObjects);
 Just like [`insert`](#insert) but also fetches the model afterwards.
 
 Note that on postgresql you can just chain [`returning('*')`](#returning) to the normal insert method
-to get the same result without an additional query. See [this recipe](#postgresql-returning-tricks) for some examples.
+to get the same result without an additional query. See [this recipe](#postgresql-quot-returning-quot-tricks) for some examples.
 
 ##### Arguments
 
@@ -514,7 +514,7 @@ want to update a subset of properties use the [`patch`](#patch) method.
 
 NOTE: The return value of the query will be the number of affected rows. If you want to update a single row and
 retrieve the updated row as a result, you may want to use the [`updateAndFetchById`](#updateandfetchbyid) method
-or *take a look at [this recipe](#postgresql-returning-tricks) if you're using Postgres*.
+or *take a look at [this recipe](#postgresql-quot-returning-quot-tricks) if you're using Postgres*.
 
 ##### Arguments
 
@@ -567,7 +567,7 @@ This method is meant for updating _whole_ objects with all required properties. 
 want to update a subset of properties use the [`patchAndFetchById`](#patchandfetchbyid) method.
 
 NOTE: On postgresql you can just chain [`first()`](#first) and [`returning('*')`](#returning) to the normal [`update`](#update) method
-to get the same result without an additional query. See [this recipe](#postgresql-returning-tricks) for some examples.
+to get the same result without an additional query. See [this recipe](#postgresql-quot-returning-quot-tricks) for some examples.
 
 ##### Arguments
 
@@ -622,7 +622,7 @@ This method is meant for updating _whole_ objects with all required properties. 
 want to update a subset of properties use the [`patchAndFetch`](#patchandfetch) method.
 
 NOTE: On postgresql you can just chain [`first()`](#first) and [`returning('*')`](#returning) to the normal [`update`](#update) method
-to get the same result without an additional query. See [this recipe](#postgresql-returning-tricks) for some examples.
+to get the same result without an additional query. See [this recipe](#postgresql-quot-returning-quot-tricks) for some examples.
 
 ##### Arguments
 
@@ -677,7 +677,7 @@ If validation fails the Promise is rejected with a [`ValidationError`](#validati
 
 NOTE: The return value of the query will be the number of affected rows. If you want to patch a single row and
 retrieve the patched row as a result, you may want to use the [`patchAndFetchById`](#patchandfetchbyid) method
-or *take a look at [this recipe](#postgresql-returning-tricks) if you're using Postgres*.
+or *take a look at [this recipe](#postgresql-quot-returning-quot-tricks) if you're using Postgres*.
 
 ##### Arguments
 
@@ -729,7 +729,7 @@ but an error isn't thrown if the patch object doesn't contain all required prope
 If validation fails the Promise is rejected with a [`ValidationError`](#validationerror).
 
 NOTE: On postgresql you can just chain [`first()`](#first) and [`returning('*')`](#returning) to the normal [`patch`](#patch) method
-to get the same result without an additional query. See [this recipe](#postgresql-returning-tricks) for some examples.
+to get the same result without an additional query. See [this recipe](#postgresql-quot-returning-quot-tricks) for some examples.
 
 ##### Arguments
 
@@ -783,7 +783,7 @@ but an error isn't thrown if the patch object doesn't contain all required prope
 If validation fails the Promise is rejected with a [`ValidationError`](#validationerror).
 
 NOTE: On postgresql you can just chain [`first()`](#first) and [`returning('*')`](#returning) to the normal [`patch`](#patch) method
-to get the same result without an additional query. See [this recipe](#postgresql-returning-tricks) for some examples.
+to get the same result without an additional query. See [this recipe](#postgresql-quot-returning-quot-tricks) for some examples.
 
 ##### Arguments
 

--- a/doc/includes/RECIPES.md
+++ b/doc/includes/RECIPES.md
@@ -296,7 +296,7 @@ Person
 ```js
 Person
   .query()
-  .select('parent:parent.name as grandParentName'
+  .select('parent:parent.name as grandParentName')
   .joinRelation('parent.parent')
   .then(people => {
     console.log(people[0].grandParentName);
@@ -353,7 +353,7 @@ jennifer
 
 ```
 
-> Delete all Persons named Jennifer and return the deleted rows in 1 query:
+> Delete all Persons named Jennifer and return the deleted instances in 1 query:
 
 ```js
 Person
@@ -368,7 +368,7 @@ Person
 
 ```
 
-> Delete all of Jennifer's dogs and return the deleted rows in 1 query:
+> Delete all of Jennifer's dogs and return the deleted instances in 1 query:
 
 ```js
 jennifer
@@ -376,16 +376,15 @@ jennifer
   .delete()
   .where({'species': 'dog'})
   .returning('*')
-  .then(deletedDogs => {
-    console.log(deletedDogs.length); // However many dogs Jennifer had
-    console.log(deletedDogs[0].name); // Maybe "Fido"
+  .then(jennsDeletedDogs => {
+    console.log(jennsDeletedDogs.length); // However many dogs Jennifer had
+    console.log(jennsDeletedDogs[0].name); // Maybe "Fido"
   });
 
 ```
 
 Because PostgreSQL (and some others) support `returning('*')` chaining, you can actually `insert` a row, or
-`update` / `patch` an existing row, __and__ receive the affected row(s) in a single query, thus improving
-efficiency. See the examples for more clarity.
+`update` / `patch` / `delete` a(n) existing row(s), __and__ receive the affected row(s) in a single query, thus improving efficiency. See the examples for more clarity.
 
 ## Polymorphic associations
 

--- a/doc/includes/RECIPES.md
+++ b/doc/includes/RECIPES.md
@@ -353,6 +353,36 @@ jennifer
 
 ```
 
+> Delete all Persons named Jennifer and return the deleted rows in 1 query:
+
+```js
+Person
+  .query()
+  .delete()
+  .where({firstName: 'Jenn'})
+  .returning('*')
+  .then(deletedJennifers => {
+    console.log(deletedJennifers.length); // However many Jennifers there were
+    console.log(deletedJennifers[0].lastName); // Maybe "Lawrence"
+  });
+
+```
+
+> Delete all of Jennifer's dogs and return the deleted rows in 1 query:
+
+```js
+jennifer
+  .$relatedQuery('pets')
+  .delete()
+  .where({'species': 'dog'})
+  .returning('*')
+  .then(deletedDogs => {
+    console.log(deletedDogs.length); // However many dogs Jennifer had
+    console.log(deletedDogs[0].name); // Maybe "Fido"
+  });
+
+```
+
 Because PostgreSQL (and some others) support `returning('*')` chaining, you can actually `insert` a row, or
 `update` / `patch` an existing row, __and__ receive the affected row(s) in a single query, thus improving
 efficiency. See the examples for more clarity.

--- a/doc/includes/RECIPES.md
+++ b/doc/includes/RECIPES.md
@@ -384,7 +384,7 @@ jennifer
 ```
 
 Because PostgreSQL (and some others) support `returning('*')` chaining, you can actually `insert` a row, or
-`update` / `patch` / `delete` a(n) existing row(s), __and__ receive the affected row(s) in a single query, thus improving efficiency. See the examples for more clarity.
+`update` / `patch` / `delete` (an) existing row(s), __and__ receive the affected row(s) in a single query, thus improving efficiency. See the examples for more clarity.
 
 ## Polymorphic associations
 


### PR DESCRIPTION
- Added more Postgres "returning" tricks examples for `delete()`.
- Find/replaced incorrect relative link/anchor from my prior doc updates.
- Fixed an unmatched paren from some earlier doc entry.