### PR TITLE
Adding tests for PostgreSQL delete returning

### DIFF
--- a/doc/includes/RECIPES.md
+++ b/doc/includes/RECIPES.md
@@ -262,7 +262,7 @@ the [`joinRelation`](#joinrelation) method family.
 
 ## PostgreSQL "returning" tricks
 
-> Insert and return the data in 1 query:
+> Insert and return a Model instance in 1 query:
 
 ```js
 Person
@@ -271,12 +271,12 @@ Person
   .returning('*')
   .then(jennifer => {
     console.log(jennifer.createdAt); // NOW()-ish
-    console.log(jennifer.id);
+    console.log(jennifer.id); // Sequence ID
   });
 
 ```
 
-> Update a single row by ID and return the data for that row in 1 query:
+> Update a single row by ID and return the updated Model instance in 1 query:
 
 ```js
 Person
@@ -292,7 +292,7 @@ Person
 
 ```
 
-> Update a Model instance and return the data for that instance in 1 query:
+> Patch a Model instance and receive DB updates to Model instance in 1 query:
 
 ```js
 jennifer
@@ -307,7 +307,7 @@ jennifer
 
 ```
 
-> Delete all Persons named Jennifer and return the deleted instances in 1 query:
+> Delete all Persons named Jennifer and return the deleted rows as Model instances in 1 query:
 
 ```js
 Person
@@ -322,7 +322,7 @@ Person
 
 ```
 
-> Delete all of Jennifer's dogs and return the deleted instances in 1 query:
+> Delete all of Jennifer's dogs and return the deleted Model instances in 1 query:
 
 ```js
 jennifer
@@ -338,7 +338,7 @@ jennifer
 ```
 
 Because PostgreSQL (and some others) support `returning('*')` chaining, you can actually `insert` a row, or
-`update` / `patch` / `delete` (an) existing row(s), __and__ receive the affected row(s) in a single query, thus improving efficiency. See the examples for more clarity.
+`update` / `patch` / `delete` (an) existing row(s), __and__ receive the affected row(s) as Model instances in a single query, thus improving efficiency. See the examples for more clarity.
 
 ## Polymorphic associations
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -657,7 +657,7 @@ select * from "Person" where "id" = 246
 Update queries are created by chaining the [`update`](#update) or [`patch`](#patch) method to the query. The [`patch`](#patch) and [`update`](#update)
 methods return the number of updated rows. If you want the freshly updated model as a result you can use the helper
 method [`patchAndFetchById`](#patchandfetchbyid) and [`updateAndFetchById`](#updateandfetchbyid). On postgresql you can
-simply chain `.returning('*')`.
+simply chain `.returning('*')` or take a look at [this recipe](#postgresql-quot-returning-quot-tricks) for more ideas.
 
 ### Delete queries
 
@@ -678,7 +678,8 @@ Person
 delete from "Person" where lower("firstName") like '%ennif%'
 ```
 
-Delete queries are created by chaining the [`delete`](#delete) method to the query.
+Delete queries are created by chaining the [`delete`](#delete) method to the query.  
+NOTE: The return value of the query will be the number of deleted rows. *If you're using Postgres take a look at [this recipe](#postgresql-quot-returning-quot-tricks) if you'd like the deleted rows to be returned as Model instances*.
 
 ## Relation queries
 

--- a/tests/integration/delete.js
+++ b/tests/integration/delete.js
@@ -329,7 +329,7 @@ module.exports = (session) => {
               .returning('*')
               .then(deletedObjects => {
                 expect(deletedObjects).to.have.length(3);
-                child1 = _.find(deletedObjects, {id_col: 1});
+                child1 = _.find(deletedObjects, {idCol: 1});
                 expectPartEql(child1, {id_col: 1, model_2_prop_1: 'text 1'});
                 return session.knex('model_2').orderBy('id_col');
               })

--- a/tests/integration/delete.js
+++ b/tests/integration/delete.js
@@ -92,7 +92,7 @@ module.exports = (session) => {
             .returning('*')
             .then(deletedModels => {
               expect(deletedModels).to.have.length(2);
-              deleted1 = _find(deletedModels, {id: 1});
+              deleted1 = _.find(deletedModels, {id: 1});
               expectPartEql(deleted1, {id: 1, model1Prop1: 'hello 1'});
               return session.knex('Model1').orderBy('id');
             })
@@ -329,7 +329,7 @@ module.exports = (session) => {
               .returning('*')
               .then(deletedObjects => {
                 expect(deletedObjects).to.have.length(3);
-                child1 = _.find(numDeleted, {id_col: 1});
+                child1 = _.find(deletedObjects, {id_col: 1});
                 expectPartEql(child1, {id_col: 1, model_2_prop_1: 'text 1'});
                 return session.knex('model_2').orderBy('id_col');
               })


### PR DESCRIPTION
I wrote a few tests in what I think is the right spot, but I couldn't verify that they were passing on my local. Received this error:
```
2) integration tests postgres "before all" hook:
     Error: Could not connect to postgres. Make sure the server is running and the database objection_test is created. You can see the test database configurations from file /Users/newhouse/projects/objection.js/testUtils/index.js
```

If that's something I can ignore, then they're probably good?