### PR TITLE
Fix typings

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -336,23 +336,14 @@ declare module "objection" {
     insertWithRelated: Insert<T>;
     insertWithRelatedAndFetch: InsertGraphAndFetch<T>
 
-    /**
-     * @return a Promise of the number of updated rows
-     */
-    update(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
+    update(modelOrObject: Partial<T>): QueryBuilder<T>;
     updateAndFetch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     updateAndFetchById(id: Id, modelOrObject: Partial<T>): QueryBuilderSingle<T>;
 
-    /**
-     * @return a Promise of the number of patched rows
-     */
-    patch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
+    patch(modelOrObject: Partial<T>): QueryBuilder<T>;
     patchAndFetchById(id: Id, modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     patchAndFetch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
 
-    /**
-     * @return a Promise of the number of deleted rows
-     */
     deleteById(idOrIds: IdOrIds): QueryBuilderSingle<T>;
 
     relate<M extends Model>(ids: IdOrIds | Partial<M> | Partial<M>[]): this;

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -339,21 +339,21 @@ declare module "objection" {
     /**
      * @return a Promise of the number of updated rows
      */
-    update(modelOrObject: Partial<T>): QueryBuilderSingle<number>;
+    update(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     updateAndFetch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     updateAndFetchById(id: Id, modelOrObject: Partial<T>): QueryBuilderSingle<T>;
 
     /**
      * @return a Promise of the number of patched rows
      */
-    patch(modelOrObject: Partial<T>): QueryBuilderSingle<number>;
+    patch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     patchAndFetchById(id: Id, modelOrObject: Partial<T>): QueryBuilderSingle<T>;
     patchAndFetch(modelOrObject: Partial<T>): QueryBuilderSingle<T>;
 
     /**
      * @return a Promise of the number of deleted rows
      */
-    deleteById(idOrIds: IdOrIds): QueryBuilderSingle<number>;
+    deleteById(idOrIds: IdOrIds): QueryBuilderSingle<T>;
 
     relate<M extends Model>(ids: IdOrIds | Partial<M> | Partial<M>[]): this;
     unrelate(): this;


### PR DESCRIPTION
It doesn't follow that deleteById, patch or update always produce a number result (postgres `.returning('*')`) - so use the QueryBuilder result type param. For queries that do result in a number, use `.query<number>()`.

Similarly, it doesn't follow that patch or update always return a single result so full QueryBuilder here.