### PR TITLE
correct typo on example `$beforeInsert` hook

### DIFF
--- a/doc/includes/RECIPES.md
+++ b/doc/includes/RECIPES.md
@@ -89,7 +89,7 @@ Composite key can be defined by using an array of column names.
 
 ```js
 class Person extends Model {
-  beforeInsert() {
+  $beforeInsert() {
     if (this.id) {
       throw new objection.ValidationError({
         id: [{


### PR DESCRIPTION
hook is named `$beforeInsert` not `beforeInsert`