### PR TITLE
Add typing for creating "transaction objects" with objection.transaction()

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -528,6 +528,8 @@ declare module "objection" {
       callback: (boundModel1Class: MC1, boundModel2Class: MC2, boundModel3Class: MC3, boundModel4Class: MC4, boundModel5Class: MC5) => Promise<T>
     ): Promise<T>;
 
+    <T>(knex: knex, callback: (trx: Transaction) => Promise<T>): Promise<T>;
+
   }
 
   export const transaction: transaction


### PR DESCRIPTION
Fixes #421

This PR adds an overload to `objection.transaction` that supports the "passing around a transaction object" style of transactions (as described in [the docs](http://vincit.github.io/objection.js/#passing-around-a-transaction-object)).

This allows Typescript users to do the following, for example:

``` js
objection.transaction(knex, (trx) => runSomeQueries(trx));
```

Previously, attempting to do so would give you a type error despite it being valid Objection code:

```
Argument of type 'Knex' is not assignable to parameter of type 'ModelClass<any>'.
  Property 'tableName' is missing in type 'Knex'. (2345)
```

See also an associated issue (which I went ahead and made for documentation reasons: #421).