### PR TITLE
Remove unnecessary await in return

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -5100,7 +5100,7 @@ objection.transaction(Person.knex(), async (trx) => {
     .query()
     .insert({firstName: 'Jennifer'});
 
-  return await TransactingPerson
+  return TransactingPerson
     .query()
     .patch({lastName: 'Lawrence'})
     .where('id', jennifer.id);

--- a/doc/index.md
+++ b/doc/index.md
@@ -1129,7 +1129,7 @@ try {
       .query(trx)
       .insert({firstName: 'Jennifer', lastName: 'Lawrence'})
 
-    return await jennifer
+    return jennifer
       .$relatedQuery('pets', trx)
       .insert({name: 'Scrappy'});
   });

--- a/examples/express-es7/src/api.js
+++ b/examples/express-es7/src/api.js
@@ -130,7 +130,7 @@ export default function (router) {
         throwNotFound();
       }
        
-      return await person
+      return person
         .$relatedQuery('movies', trx)
         .insert(req.body); 
     });


### PR DESCRIPTION
There is no need to use `await` in return. [Eslint rule](http://eslint.org/docs/rules/no-return-await) with explanation.