### PR TITLE
Update types to compile with TypeScript 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "knex": "0.x"
   },
   "devDependencies": {
-    "@types/knex": "^0.0.50",
+    "@types/knex": "^0.0.55",
     "coveralls": "^2.13.1",
     "expect.js": "^0.3.1",
     "fs-extra": "3.0.1",
@@ -67,6 +67,6 @@
     "mysql": "^2.13.0",
     "pg": "^6.2.2",
     "sqlite3": "^3.1.8",
-    "typescript": "^2.3.2"
+    "typescript": "^2.4.1"
   }
 }

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-unused-variable
 import * as knex from 'knex';
-import * as objection from 'objection';
+import * as objection from '../../typings/objection';
 
 // This file exercises the Objection.js typings.
 
@@ -238,7 +238,7 @@ objection.transaction(Movie, Person, Animal, Comment, PersonActor, async (TxMovi
   }
 });
 
-objection.transaction.start(Person).then((trx: objection.Transaction) => {
+objection.transaction.start(Person).then(trx => {
   const TxPerson: typeof Person = Person.bindTransaction(trx)
   TxPerson.query()
     .then(() => trx.commit())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,19 @@
 {
   "compilerOptions": {
     "allowJs": false,
+    "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "noEmit": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": false,
+    "strict": true,
     "strictNullChecks": true,
-    "experimentalDecorators": true,
-    "noEmit": true,
-    "target": "es6",
-    "typeRoots": [
-      "typings",
-      "node_modules/@types"
-    ]
+    "target": "es6"
   },
   "files": [
     "tests/ts/examples.ts"
   ]
 }
-


### PR DESCRIPTION
* Synced up with new knex types
* Removed spurious "orderBy" in relation mappings (oops)
* Fixed return values from {} to be correct (which were highlighted by the new TypeScript compiler)