### PR TITLE
Add objection-guid plugin

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1399,6 +1399,7 @@ are accepted on this list. Other modules like plugins for other frameworks and t
 practices are an exception to this rule. If you are a developer or otherwise know of a good plugin/module for objection, please 
 create a pull request or an issue to get it added to this list.
 
+  * [objection-guid](https://github.com/seegno/objection-guid) - automatic guid for your models
   * [objection-password](https://github.com/scoutforpets/objection-password) - automatic password hashing for your models
   * [objection-visibility](https://github.com/oscaroox/objection-visibility) - whitelist/blacklist your model properties
 


### PR DESCRIPTION
This adds the [objection-guid](https://github.com/seegno/objection-guid) to the list of plugins.