### PR TITLE
Fix `throwIfNotFound` when query result is zero

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -82,7 +82,7 @@ class QueryBuilder extends QueryBuilderBase {
   tableNameFor(modelClass) {
     const ctx = this.internalContext();
     const tableMap = ctx.tableMap;
-    
+
     return (tableMap && tableMap[modelClass.tableName]) || modelClass.tableName;
   }
 
@@ -536,7 +536,7 @@ class QueryBuilder extends QueryBuilderBase {
     return this.runAfter((result, builder) => {
       if (Array.isArray(result) && result.length === 0) {
         throw this._modelClass.createNotFoundError(builder.context());
-      } else if (result === null || result === undefined) {
+      } else if (result === null || result === undefined || result === 0) {
         throw this._modelClass.createNotFoundError(builder.context());
       } else {
         return result;

--- a/tests/integration/find.js
+++ b/tests/integration/find.js
@@ -300,6 +300,22 @@ module.exports = (session) => {
             .catch(done);
         });
 
+        it('.throwIfNotFound() with result equal to 0', (done) => {
+          Model1
+            .query()
+            .where('model1Prop1', 'There is no value like me')
+            .delete()
+            .throwIfNotFound()
+            .then(() => {
+              done(new Error('should not get here'));
+            })
+            .catch(err => {
+              expect(err).to.be.a(Model1.NotFoundError);
+              done();
+            })
+            .catch(done);
+        });
+
         it('.throwIfNotFound() should throw error returned by `createNotFoundError`', (done) => {
           class CustomError extends Error {
             constructor(ctx) {


### PR DESCRIPTION
This fixes the `throwIfNotFound` method when the query result is `0` (number of affected rows). 

Closes #469 