### PR TITLE
Added .raw to Objection namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "knex": "0.x"
   },
   "devDependencies": {
-    "@types/knex": "^0.0.55",
-    "@types/node": "^8.0.17",
+    "@types/knex": "^0.0.61",
+    "@types/node": "^8.0.28",
     "coveralls": "^2.13.1",
     "expect.js": "^0.3.1",
     "fs-extra": "3.0.1",
@@ -69,7 +69,7 @@
     "mysql": "^2.13.0",
     "pg": "^6.2.2",
     "sqlite3": "^3.1.8",
-    "tslint": "^5.5.0",
-    "typescript": "^2.4.2"
+    "tslint": "^5.7.0",
+    "typescript": "^2.5.2"
   }
 }

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -14,27 +14,29 @@ class Person extends objection.Model {
   examplePersonMethod = (arg: string) => 1;
 
   static async truncate(): Promise<void> {
-    await this.query().truncate()
+    await this.query().truncate();
   }
 
   static async withLastName(lastName: string): Promise<Person[]> {
-    return this.query().where('lastName', lastName)
+    return this.query().where('lastName', lastName);
   }
 
   static async firstWithLastName(lastName: string): Promise<Person | undefined> {
-    return this.query().where({lastName: lastName}).first()
+    return this.query()
+      .where({ lastName })
+      .first();
   }
 
   static async findById(id: number): Promise<Person | undefined> {
-    return this.query().findById(id)
+    return this.query().findById(id);
   }
 
   static async findWithFirstName(firstname: string): Promise<Person | undefined> {
-    return this.query().findOne({firstName: firstname})
+    return this.query().findOne({ firstName: firstname });
   }
 
   async loadMovies(): Promise<this> {
-    return this.$loadRelated('movies')
+    return this.$loadRelated('movies');
   }
 
   async reload(): Promise<this> {
@@ -43,13 +45,13 @@ class Person extends objection.Model {
 
   async petsWithId(petId: number): Promise<Animal[]> {
     // Types can't look at strings and give strong types, so this must be a Model[] promise:
-    const pets: objection.Model[] = await this.$relatedQuery('pets').where('id', petId)
+    const pets: objection.Model[] = await this.$relatedQuery('pets').where('id', petId);
     // that we can subsequently cast to Animal:
-    return pets as Animal[]
+    return pets as Animal[];
   }
 
   async $beforeInsert(queryContext: objection.QueryContext) {
-    console.log(queryContext.someCustomValue)
+    console.log(queryContext.someCustomValue);
   }
 }
 
@@ -76,11 +78,11 @@ const BoundPerson: typeof Person = Person.bindKnex(k);
 // With expected static methods:
 Person.bindKnex(k).truncate();
 
-// The Model subclass is interpreted correctly to be constructable 
+// The Model subclass is interpreted correctly to be constructable
 
 const examplePerson: Person = new BoundPerson();
 
-// and to have expected sublcass fields 
+// and to have expected sublcass fields
 
 examplePerson.firstName = 'example';
 examplePerson.lastName = 'person';
@@ -93,7 +95,9 @@ const exampleResult: number = examplePerson.examplePersonMethod('hello');
 
 const personId = examplePerson.$id();
 const exampleJsonPerson: Person = examplePerson.$setJson({ id: 'hello' });
-const exampleDatabaseJsonPerson: Person = examplePerson.$setDatabaseJson({ id: 'hello' });
+const exampleDatabaseJsonPerson: Person = examplePerson.$setDatabaseJson({
+  id: 'hello'
+});
 const omitPersonFromKey: Person = examplePerson.$omit('lastName');
 const omitPersonFromObj: Person = examplePerson.$omit({ firstName: true });
 const pickPersonFromKey: Person = examplePerson.$pick('lastName');
@@ -102,18 +106,18 @@ const clonePerson: Person = examplePerson.$clone();
 
 // static methods from Model should return the subclass type
 
-Person.loadRelated([new Person()], 'movies').then((people: Person[]) => { });
+const people: Promise<Person[]> = Person.loadRelated([new Person()], 'movies');
 
 class Actor {
-  canAct: boolean
+  canAct: boolean;
 }
 
 // test .extend:
 const PersonActor = Person.extend(Actor);
 
-const pa = new PersonActor()
-pa.firstName = 'chuck'
-pa.canAct = false
+const pa = new PersonActor();
+pa.firstName = 'chuck';
+pa.canAct = false;
 
 // Optional<Person> typing for findById():
 
@@ -161,31 +165,43 @@ qb = qb.joinRelation('table', { alias: false });
 
 // signature-changing QueryBuilder methods:
 
-const rowInserted: Promise<Person> = qb.insert({ firstName: 'bob' })
-const rowsInserted: Promise<Person[]> = qb.insert([{ firstName: 'alice' }, { firstName: 'bob' }])
-const rowsInsertedWithRelated: Promise<Person> = qb.insertWithRelated({})
-const rowsUpdated: Promise<number> = qb.update({})
-const rowsPatched: Promise<number> = qb.patch({})
-const rowsDeleted: Promise<number> = qb.deleteById(123)
-const rowsDeleted2: Promise<number> = qb.deleteById([123, 456])
+const rowInserted: Promise<Person> = qb.insert({ firstName: 'bob' });
+const rowsInserted: Promise<Person[]> = qb.insert([{ firstName: 'alice' }, { firstName: 'bob' }]);
+const rowsInsertedWithRelated: Promise<Person> = qb.insertWithRelated({});
+const rowsUpdated: Promise<number> = qb.update({});
+const rowsPatched: Promise<number> = qb.patch({});
+const rowsDeleted: Promise<number> = qb.deleteById(123);
+const rowsDeleted2: Promise<number> = qb.deleteById([123, 456]);
 
-const insertedModel: Promise<Person> = Person.query().insertAndFetch({})
-const insertedModels: Promise<Person[]> = Person.query().insertGraphAndFetch([new Person(), new Person()])
+const insertedModel: Promise<Person> = Person.query().insertAndFetch({});
+const insertedModels: Promise<Person[]> = Person.query().insertGraphAndFetch([
+  new Person(),
+  new Person()
+]);
 
-const upsertModel1: Promise<Person> = Person.query().upsertGraph({})
-const upsertModel2: Promise<Person> = Person.query().upsertGraph({}, {relate: true})
-const upsertModels1: Promise<Person[]> = Person.query().upsertGraph([])
-const upsertModels2: Promise<Person[]> = Person.query().upsertGraph([], {unrelate: true})
+const upsertModel1: Promise<Person> = Person.query().upsertGraph({});
+const upsertModel2: Promise<Person> = Person.query().upsertGraph({}, { relate: true });
+const upsertModels1: Promise<Person[]> = Person.query().upsertGraph([]);
+const upsertModels2: Promise<Person[]> = Person.query().upsertGraph([], {
+  unrelate: true
+});
 
-const insertedGraphAndFetchOne: Promise<Person> = Person.query().insertGraphAndFetch(new Person())
-const insertedGraphAndFetchSome: Promise<Person[]> = Person.query().insertGraphAndFetch([new Person(), new Person()])
-const insertedRelatedAndFetch: Promise<Person> = Person.query().insertWithRelatedAndFetch(new Person())
-const updatedModel: Promise<Person> = Person.query().updateAndFetch({})
-const updatedModelById: Promise<Person> = Person.query().updateAndFetchById(123, {})
-const patchedModel: Promise<Person> = Person.query().patchAndFetch({})
-const patchedModelById: Promise<Person> = Person.query().patchAndFetchById(123, {})
+const insertedGraphAndFetchOne: Promise<Person> = Person.query().insertGraphAndFetch(new Person());
+const insertedGraphAndFetchSome: Promise<Person[]> = Person.query().insertGraphAndFetch([
+  new Person(),
+  new Person()
+]);
+const insertedRelatedAndFetch: Promise<Person> = Person.query().insertWithRelatedAndFetch(
+  new Person()
+);
+const updatedModel: Promise<Person> = Person.query().updateAndFetch({});
+const updatedModelById: Promise<Person> = Person.query().updateAndFetchById(123, {});
+const patchedModel: Promise<Person> = Person.query().patchAndFetch({});
+const patchedModelById: Promise<Person> = Person.query().patchAndFetchById(123, {});
 
-const eager: Promise<Person[]> = Person.query().eagerAlgorithm(Person.NaiveEagerAlgorithm).eager('foo.bar')
+const eager: Promise<Person[]> = Person.query()
+  .eagerAlgorithm(Person.NaiveEagerAlgorithm)
+  .eager('foo.bar');
 
 // non-wrapped methods:
 
@@ -193,10 +209,9 @@ const modelFromQuery: typeof objection.Model = qb.modelClass();
 
 const sql: string = qb.toSql();
 
-qb = qb.whereJsonEquals(
-  'Person.jsonColumnName:details.names[1]',
-  { details: { names: ['First', 'Second', 'Last'] } }
-);
+qb = qb.whereJsonEquals('Person.jsonColumnName:details.names[1]', {
+  details: { names: ['First', 'Second', 'Last'] }
+});
 qb = qb.whereJsonEquals('additionalData:myDogs', 'additionalData:dogsAtHome');
 qb = qb.whereJsonEquals('additionalData:myDogs[0]', { name: 'peter' });
 qb = qb.whereJsonNotEquals('jsonObject:a', 'jsonObject:b');
@@ -206,11 +221,11 @@ function noop() {
   // no-op
 }
 
-const qbcb = (qb: objection.QueryBuilder<Person>) => noop()
+const qbcb = (ea: objection.QueryBuilder<Person>) => noop();
 
 qb = qb.context({
-  runBefore: qbcb,
   runAfter: qbcb,
+  runBefore: qbcb,
   onBuild: qbcb
 });
 
@@ -239,26 +254,39 @@ objection.transaction(Movie, Person, Animal, async (TxMovie, TxPerson, TxAnimal)
   const s: string = new TxAnimal().species;
 });
 
-objection.transaction(Movie, Person, Animal, Comment, async (TxMovie, TxPerson, TxAnimal, TxComment) => {
-  const t: string = new TxMovie().title;
-  const n: number = new TxPerson().examplePersonMethod('hello');
-  const s: string = new TxAnimal().species;
-  const c: string = new TxComment().comment
-});
-
-objection.transaction(Movie, Person, Animal, Comment, PersonActor, async (TxMovie, TxPerson, TxAnimal, TxComment, TxPersonActor) => {
-  const t: string = new TxMovie().title;
-  const n: number = new TxPerson().examplePersonMethod('hello');
-  const s: string = new TxAnimal().species;
-  const c: string = new TxComment().comment
-  const pa = new TxPersonActor()
-  if (pa.canAct) {
-    const n: number = pa.examplePersonMethod('arg')
+objection.transaction(
+  Movie,
+  Person,
+  Animal,
+  Comment,
+  async (TxMovie, TxPerson, TxAnimal, TxComment) => {
+    const t: string = new TxMovie().title;
+    const n: number = new TxPerson().examplePersonMethod('hello');
+    const s: string = new TxAnimal().species;
+    const c: string = new TxComment().comment;
   }
-});
+);
 
-objection.transaction.start(Person).then(trx => {
-  const TxPerson: typeof Person = Person.bindTransaction(trx)
+objection.transaction(
+  Movie,
+  Person,
+  Animal,
+  Comment,
+  PersonActor,
+  async (TxMovie, TxPerson, TxAnimal, TxComment, TxPersonActor) => {
+    const t: string = new TxMovie().title;
+    const n: number = new TxPerson().examplePersonMethod('hello');
+    const s: string = new TxAnimal().species;
+    const c: string = new TxComment().comment;
+    const tpa = new TxPersonActor();
+    if (tpa.canAct) {
+      const ea: number = pa.examplePersonMethod('arg');
+    }
+  }
+);
+
+objection.transaction.start(Person).then((trx) => {
+  const TxPerson: typeof Person = Person.bindTransaction(trx);
   TxPerson.query()
     .then(() => trx.commit())
     .catch(() => trx.rollback());
@@ -272,9 +300,10 @@ const p: Promise<string> = qb.then(() => 'done');
 // Verify that we can insert a partial model and relate a partial movie
 Person.query()
   .insertAndFetch({ firstName: 'Jim' })
-  .then((p: Person) => {
+  .then((ea: Person) => {
     console.log(`Inserted ${p}`);
-    p.$loadRelated('movies')
+    ea
+      .$loadRelated('movies')
       .relate<Movie>({ title: 'Total Recall' })
       .then((pWithMovie: Person) => {
         console.log(`Related ${pWithMovie}`);
@@ -283,31 +312,27 @@ Person.query()
 
 // Verify we can call `.insert` with a Partial<Person>:
 
-Person
-  .query()
-  .insert({ firstName: 'Chuck' })
+Person.query().insert({ firstName: 'Chuck' });
 
-// Verify we can call `.insert` via $relatedQuery 
+// Verify we can call `.insert` via $relatedQuery
 // (albeit with a cast to Movie):
 
-new Person()
-  .$relatedQuery<Movie>('movies')
-  .insert({ title: 'Total Recall' })
+new Person().$relatedQuery<Movie>('movies').insert({ title: 'Total Recall' });
 
 // Verify if is possible transaction class can be shared across models
-objection.transaction(Person.knex(), async trx => {
+objection.transaction(Person.knex(), async (trx) => {
   await Person.query(trx).insert({ firstName: 'Name' });
   await Movie.query(trx).insert({ title: 'Total Recall' });
 });
 
-objection.transaction<Person>(Person.knex(), async trx => {
+objection.transaction<Person>(Person.knex(), async (trx) => {
   const person = await Person.query(trx).insert({ firstName: 'Name' });
   await Movie.query(trx).insert({ title: 'Total Recall' });
 
   return person;
 });
 
-objection.transaction.start(Person).then(trx => {
+objection.transaction.start(Person).then((trx) => {
   Movie.query(trx)
     .then(() => trx.commit())
     .catch(() => trx.rollback());
@@ -316,10 +341,6 @@ objection.transaction.start(Person).then(trx => {
 // Vefiry whereIn accepts a queryBuilder of any
 const whereInSubquery = Movie.query().select('name');
 
-Person
-  .query()
-  .whereIn('firstName', whereInSubquery);
+Person.query().whereIn('firstName', whereInSubquery);
 
-Person
-  .query()
-  .whereExists(whereInSubquery);
+Person.query().whereExists(whereInSubquery);

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -238,7 +238,7 @@ qb = qb.runBefore(qbcb);
 qb = qb.reject('fail');
 qb = qb.resolve('success');
 
-objection.transaction(Person, (TxPerson) => {
+objection.transaction(Person, TxPerson => {
   const n: number = new TxPerson().examplePersonMethod('hello');
   return Promise.resolve('yay');
 });
@@ -285,7 +285,7 @@ objection.transaction(
   }
 );
 
-objection.transaction.start(Person).then((trx) => {
+objection.transaction.start(Person).then(trx => {
   const TxPerson: typeof Person = Person.bindTransaction(trx);
   TxPerson.query()
     .then(() => trx.commit())
@@ -320,19 +320,19 @@ Person.query().insert({ firstName: 'Chuck' });
 new Person().$relatedQuery<Movie>('movies').insert({ title: 'Total Recall' });
 
 // Verify if is possible transaction class can be shared across models
-objection.transaction(Person.knex(), async (trx) => {
+objection.transaction(Person.knex(), async trx => {
   await Person.query(trx).insert({ firstName: 'Name' });
   await Movie.query(trx).insert({ title: 'Total Recall' });
 });
 
-objection.transaction<Person>(Person.knex(), async (trx) => {
+objection.transaction<Person>(Person.knex(), async trx => {
   const person = await Person.query(trx).insert({ firstName: 'Name' });
   await Movie.query(trx).insert({ title: 'Total Recall' });
 
   return person;
 });
 
-objection.transaction.start(Person).then((trx) => {
+objection.transaction.start(Person).then(trx => {
   Movie.query(trx)
     .then(() => trx.commit())
     .catch(() => trx.rollback());
@@ -344,3 +344,10 @@ const whereInSubquery = Movie.query().select('name');
 Person.query().whereIn('firstName', whereInSubquery);
 
 Person.query().whereExists(whereInSubquery);
+
+// Example of raw select, where, and orderby from docs:
+
+Person.query()
+  .select(objection.raw('coalesce(sum(??), 0) as ??', ['age', 'childAgeSum']))
+  .where(objection.raw(`?? || ' ' || ??`, 'firstName', 'lastName'), 'Arnold Schwarzenegger')
+  .orderBy(objection.raw('random()'));

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "extends": ["tslint:recommended"],
   "jsRules": {},
   "rules": {
+    "arrow-parens": false,
     "class-name": false,
     "interface-name": [false],
     "max-classes-per-file": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,6 @@
 {
   "defaultSeverity": "error",
-  "extends": [
-    "tslint:recommended"
-  ],
+  "extends": ["tslint:recommended"],
   "jsRules": {},
   "rules": {
     "class-name": false,
@@ -10,12 +8,16 @@
     "max-classes-per-file": [false],
     "member-access": [false],
     "member-ordering": [false],
+    "no-console": false,
     "no-namespace": [false],
-    "no-empty-interface": [false],
     "no-unused-expression": [false],
+    "object-literal-sort-keys": [
+      false
+    ],
+    "quotemark": ["single"],
     "semicolon": [true, "always"],
     "space-before-function-paren": [false],
-    "trailing-comma": [false, "always"],
+    "trailing-comma": [false],
     "array-type": [false, "array-simple"],
     "unified-signatures": false
   },

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for objection v0.8.4
+// Type definitions for objection v0.9.0
 // Project: Objection.js <http://vincit.github.io/objection.js/>
 // Definitions by: Matthew McEachen <https://github.com/mceachen> & Drew R. <https://github.com/drew-r>
 
@@ -8,6 +8,9 @@ import * as knex from "knex";
 export = Objection;
 
 declare namespace Objection {
+
+  const raw: knex.RawBuilder
+
   export interface ModelOptions {
     patch?: boolean;
     skipValidation?: boolean;
@@ -783,7 +786,7 @@ declare namespace Objection {
     (raw: Raw): QueryBuilder<T>;
     (callback: (queryBuilder: QueryBuilder<T>) => any): QueryBuilder<T>;
     (object: object): QueryBuilder<T>;
-    (columnName: string, value: Value): QueryBuilder<T>;
+    (columnName: string | Raw, value: Value): QueryBuilder<T>;
     (columnName: string | Raw, operator: string, value: Value): QueryBuilder<T>;
     (columnName: string | Raw, operator: string, query: QueryBuilder<T>): QueryBuilder<T>;
     (columnName: string, callback: (queryBuilder: QueryBuilder<T>) => any): QueryBuilder<T>;
@@ -828,7 +831,7 @@ declare namespace Objection {
   }
 
   interface OrderBy<T> {
-    (columnName: string, direction?: string): QueryBuilder<T>;
+    (columnName: string | Raw, direction?: string): QueryBuilder<T>;
   }
 
   interface Union<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,19 +3,19 @@
 
 
 "@types/bluebird@*":
-  version "3.5.8"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.8.tgz#242a83379f06c90f96acf6d1aeab3af6faebdb98"
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.10.tgz#c4b09b7ffa4b1b2baec2b03eca8618687099acb0"
 
-"@types/knex@^0.0.55":
-  version "0.0.55"
-  resolved "https://registry.yarnpkg.com/@types/knex/-/knex-0.0.55.tgz#4cbbd07bcb9fc306af315225822335e301eeeffb"
+"@types/knex@^0.0.61":
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/@types/knex/-/knex-0.0.61.tgz#3825ec6fe0886237dbce02d1398ae8dfdc19f4b3"
   dependencies:
     "@types/bluebird" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^8.0.17":
-  version "8.0.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"
+"@types/node@*", "@types/node@^8.0.28":
+  version "8.0.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
 
 abbrev@1:
   version "1.1.0"
@@ -262,8 +262,8 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
 core-js@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -301,6 +301,10 @@ decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -308,6 +312,17 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -328,14 +343,32 @@ diff@3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+es-abstract@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
@@ -439,6 +472,12 @@ flagged-respawn@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5"
 
+for-each@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+  dependencies:
+    is-function "~1.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -448,6 +487,10 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -493,6 +536,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -565,7 +612,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.5, glob@^7.1.1, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -648,6 +695,12 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has@^1.0.1, has@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -656,6 +709,10 @@ hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -698,6 +755,14 @@ is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -721,6 +786,10 @@ is-fullwidth-code-point@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   dependencies:
     number-is-nan "^1.0.0"
+
+is-function@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -760,6 +829,16 @@ is-primitive@^2.0.0:
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1018,15 +1097,15 @@ micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
 mime-types@^2.1.12, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
-    mime-db "~1.29.0"
+    mime-db "~1.30.0"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
@@ -1038,7 +1117,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1057,8 +1136,8 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 mocha@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.0.tgz#1328567d2717f997030f8006234bce9b8cd72465"
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.1.tgz#9b6d13ac1ccf957edd16f2e439055734b1b60391"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -1067,6 +1146,7 @@ mocha@^3.4.1:
     escape-string-regexp "1.0.5"
     glob "7.1.1"
     growl "1.9.2"
+    he "1.1.1"
     json3 "3.3.2"
     lodash.create "3.1.1"
     mkdirp "0.5.1"
@@ -1085,13 +1165,13 @@ mysql@^2.13.0:
     safe-buffer "5.1.1"
     sqlstring "2.2.0"
 
-nan@~2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+nan@~2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
-node-pre-gyp@~0.6.36:
-  version "0.6.36"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
+node-pre-gyp@~0.6.37:
+  version "0.6.37"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -1100,6 +1180,7 @@ node-pre-gyp@~0.6.36:
     request "^2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
+    tape "^4.6.3"
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
@@ -1146,6 +1227,14 @@ object-assign@4.1.0:
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -1361,11 +1450,10 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regex-cache@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
-    is-primitive "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -1442,11 +1530,17 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
+
+resumer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  dependencies:
+    through "~2.3.4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1513,11 +1607,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sqlite3@^3.1.8:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.9.tgz#b2e7fbaa348380318d3834323918c3c351b8bf18"
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.10.tgz#b1f10dfc5d487b079fda2f34fbf60cbaf6d92ad3"
   dependencies:
-    nan "~2.6.2"
-    node-pre-gyp "~0.6.36"
+    nan "~2.7.0"
+    node-pre-gyp "~0.6.37"
 
 sqlstring@2.2.0:
   version "2.2.0"
@@ -1544,6 +1638,14 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+string.prototype.trim@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -1585,6 +1687,24 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
+tape@^4.6.3:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.2"
+    function-bind "~1.1.0"
+    glob "~7.1.2"
+    has "~1.0.1"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.3.0"
+    resolve "~1.4.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
+
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
@@ -1606,7 +1726,7 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-through@2:
+through@2, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -1626,7 +1746,7 @@ tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
-tslint@^5.5.0:
+tslint@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.7.0.tgz#c25e0d0c92fa1201c2bc30e844e08e682b4f3552"
   dependencies:
@@ -1667,9 +1787,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.4.2:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
+typescript@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
This PR addresses the first third of #499 

* Added `raw` to the top-level namespace
* Upgraded typescript to 2.5.2 and tslint
* Ran `prettier` on example.ts (which caused most of this diff), which fixed several missing semis and inconsistent parens/whitespace
* Fixed linting errors
* Added `.raw` calls to the bottom of `example.ts` from the docs
* Updated `Where` and `OrderBy` to accept the new examples
