### PR TITLE
query, $query, and $relatedQuery can take a Knex or Transaction instance

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -372,3 +372,11 @@ Person.query()
 
 // LiteralBuilder:
 Person.query().where(ref('Model.jsonColumn:details'), '=', lit({ name: 'Jennifer', age: 29 }));
+
+// .query, .$query, and .$relatedQuery can take a Knex instance to support
+// multitenancy
+
+const peep123: Promise<Person | undefined> = BoundPerson.query(k).findById(123);
+
+new Person().$query(k).execute();
+new Person().$relatedQuery("pets", k).execute();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -221,7 +221,7 @@ declare namespace Objection {
     ManyToManyRelation: Relation;
     HasOneThroughRelation: Relation;
 
-    query(trx?: Transaction): QueryBuilder<M>;
+    query(trxOrKnex?: Transaction | knex): QueryBuilder<M>;
     knex(knex?: knex): knex;
     formatter(): any; // < the knex typings punts here too
     knexQuery(): QueryBuilder<M>;
@@ -277,7 +277,7 @@ declare namespace Objection {
 
     // "{ new(): T }"
     // is from https://www.typescriptlang.org/docs/handbook/generics.html#using-class-types-in-generics
-    static query<T>(this: { new(): T }, trx?: Transaction): QueryBuilder<T>;
+    static query<T>(this: { new(): T }, trxOrKnex?: Transaction | knex): QueryBuilder<T>;
     static knex(knex?: knex): knex;
     static formatter(): any; // < the knex typings punts here too
     static knexQuery<T>(this: { new(): T }): QueryBuilder<T>;
@@ -330,14 +330,14 @@ declare namespace Objection {
     /**
      * AKA `reload` in ActiveRecord parlance
      */
-    $query(trx?: Transaction): QueryBuilderSingle<this>;
+    $query(trxOrKnex?: Transaction | knex): QueryBuilderSingle<this>;
 
     /**
      * Users need to explicitly type these calls, as the relationName doesn't
      * indicate the type (and if it returned Model directly, Partial<Model>
      * guards are worthless)
      */
-    $relatedQuery<M extends Model>(relationName: string, transaction?: Transaction): QueryBuilder<M>;
+    $relatedQuery<M extends Model>(relationName: string, trxOrKnex?: Transaction | knex): QueryBuilder<M>;
 
     $loadRelated<T>(expression: RelationExpression, filters?: Filters<T>): QueryBuilderSingle<this>;
 


### PR DESCRIPTION
The prior typings only allowed for a transaction object. I just found out that they also accept knex instances.