### PR TITLE
Issue #523, upsertGraph, should update if relationship property

### DIFF
--- a/lib/queryBuilder/graphUpserter/UpsertNode.js
+++ b/lib/queryBuilder/graphUpserter/UpsertNode.js
@@ -97,12 +97,17 @@ function hasChanges(currentModel, upsertModel, queryProps) {
 
     if (!relations[key] && currentModel[key] !== upsertModel[key]) {
       return true;
-    } else if (relations[key] && relations[key].constructor.name === BelongsToOneRelation.name) {
-      const idColumn = currentModel.constructor.idColumn;
-      const currentModelBelongsToOneId = currentModel[key] ? currentModel[key][idColumn] : null;
-      const upsertModelBelongsToOneId = upsertModel[key] ? upsertModel[key][idColumn] : null;
+    } else if (relations[key] instanceof BelongsToOneRelation) {
+      const relatedProp = relations[key].relatedProp;
+      const hasChanges = [];
 
-      if (currentModelBelongsToOneId !== upsertModelBelongsToOneId) {
+      for (let i = 0, l = relatedProp.size; i < l; ++i) {
+        const currentProp = currentModel[key] && relatedProp.getProp(currentModel[key], i);
+        const upsertProp = upsertModel[key] && relatedProp.getProp(upsertModel[key], i);
+        hasChanges.push(currentProp !== upsertProp);
+      }
+
+      if (hasChanges.indexOf(true) !== -1) {
         return true;
       }
     }

--- a/lib/queryBuilder/graphUpserter/UpsertNode.js
+++ b/lib/queryBuilder/graphUpserter/UpsertNode.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isTempColumn = require('../../utils/tmpColumnUtils').isTempColumn;
+const BelongsToOneRelation = require('../../relations/belongsToOne/BelongsToOneRelation');
 
 const UpsertNodeType = {
   Update: 'Update',
@@ -82,6 +83,7 @@ function copyCurrentToUpsert(currentModel, upsertModel) {
 
 function hasChanges(currentModel, upsertModel, queryProps) {
   const keys = Object.keys(upsertModel);
+  const relations = upsertModel.constructor.getRelations();
   const upsertQueryProps = queryProps.get(upsertModel);
 
   // If the upsert model has query properties, we cannot know if they will change
@@ -93,8 +95,16 @@ function hasChanges(currentModel, upsertModel, queryProps) {
   for (let i = 0, l = keys.length; i < l; ++i) {
     const key = keys[i];
 
-    if (currentModel[key] !== upsertModel[key]) {
+    if (!relations[key] && currentModel[key] !== upsertModel[key]) {
       return true;
+    } else if (relations[key] && relations[key].constructor.name === BelongsToOneRelation.name) {
+      const idColumn = currentModel.constructor.idColumn;
+      const currentModelBelongsToOneId = currentModel[key] ? currentModel[key][idColumn] : null;
+      const upsertModelBelongsToOneId = upsertModel[key] ? upsertModel[key][idColumn] : null;
+
+      if (currentModelBelongsToOneId !== upsertModelBelongsToOneId) {
+        return true;
+      }
     }
   }
 

--- a/lib/queryBuilder/graphUpserter/UpsertNode.js
+++ b/lib/queryBuilder/graphUpserter/UpsertNode.js
@@ -82,7 +82,6 @@ function copyCurrentToUpsert(currentModel, upsertModel) {
 
 function hasChanges(currentModel, upsertModel, queryProps) {
   const keys = Object.keys(upsertModel);
-  const relations = upsertModel.constructor.getRelations();
   const upsertQueryProps = queryProps.get(upsertModel);
 
   // If the upsert model has query properties, we cannot know if they will change
@@ -94,7 +93,7 @@ function hasChanges(currentModel, upsertModel, queryProps) {
   for (let i = 0, l = keys.length; i < l; ++i) {
     const key = keys[i];
 
-    if (!relations[key] && currentModel[key] !== upsertModel[key]) {
+    if (currentModel[key] !== upsertModel[key]) {
       return true;
     }
   }

--- a/tests/integration/upsertGraph.js
+++ b/tests/integration/upsertGraph.js
@@ -154,8 +154,8 @@ module.exports = (session) => {
               ]);
             }
 
-            expect(result.$beforeUpdateCalled).to.equal(1);
-            expect(result.$afterUpdateCalled).to.equal(1);
+            expect(result.$beforeUpdateCalled).to.equal(undefined);
+            expect(result.$afterUpdateCalled).to.equal(undefined);
 
             expect(result.model1Relation1.$beforeUpdateCalled).to.equal(1);
             expect(result.model1Relation1.$afterUpdateCalled).to.equal(1);
@@ -232,6 +232,27 @@ module.exports = (session) => {
               // Row 2 should be deleted.
               expect(model2Rows.find(it => it.id_col == 2)).to.equal(undefined);
             });
+          });
+      });
+    });
+
+    it('should update root only if belongsToOne relation change', () => {
+      const upsert = {
+        id: 1,
+        // update BelongsToOneRelation
+        model1Relation1: { id: 3 },
+      };
+
+      return transaction(session.knex, trx => {
+        return Model1
+          .query(trx)
+          .upsertGraph(upsert, { relate: true })
+          .then(result => {
+            expect(result.$beforeUpdateCalled).to.equal(1);
+            expect(result.$afterUpdateCalled).to.equal(1);
+
+            expect(result.model1Relation1.$beforeUpdateCalled).to.equal(undefined);
+            expect(result.model1Relation1.$afterUpdateCalled).to.equal(undefined);
           });
       });
     });


### PR DESCRIPTION
As discussed in #523.

This impose a breaking change since `$beforeUpdate` and `$afterUpdate` are now called?