### PR TITLE
Trigger an InstanceUpdateOperation from BelongsToOneInsertOperation

### DIFF
--- a/lib/relations/belongsToOne/BelongsToOneInsertOperation.js
+++ b/lib/relations/belongsToOne/BelongsToOneInsertOperation.js
@@ -30,7 +30,6 @@ class BelongsToOneInsertOperation extends InsertOperation {
     return after(maybePromise, inserted => {
       this.owner[this.relation.name] = inserted[0] || null;
 
-      const idColumn = builder.fullIdColumnFor(this.relation.ownerModelClass);
       const patch = {};
 
       for (let i = 0, l = ownerProp.size; i < l; ++i) {
@@ -40,11 +39,9 @@ class BelongsToOneInsertOperation extends InsertOperation {
         ownerProp.patch(patch, i, relatedValue);
       }
 
-      return this.relation.ownerModelClass
-        .query()
+      return this.owner.$query()
         .childQueryOf(builder)
         .patch(patch)
-        .whereComposite(idColumn, this.owner.$id())
         .return(inserted);
     });
 


### PR DESCRIPTION
Issue described @ https://gitter.im/Vincit/objection.js?at=59d2c32eb20c642429b5a9a2 and quoted below:

> I don’t know if this is expected behavior or not, so I wanted to bring it up here rather than opening an issue. When calling $relatedQuery(…).insert() on a model instance with a belongs-to relationship with the model being inserted (a BelongsToOneInsertOperation), a subsequent update is made to the model to update it with the ID of the related model that was inserted. This is done by calling:
```
return this.relation.ownerModelClass
        .query()
        .childQueryOf(builder)
        .patch(patch)
        .whereComposite(idColumn, this.owner.$id())
        .return(inserted);
```
> The issue I ran into with this is that even though the original call was on an instance, the subsequent call performs an UpdateOperation rather than an InstanceUpdateOperation, which means that the original values of the instance are missing from modelOptions.old in the subsequent $beforeUpdate call.
> It seems to me that this code could be simplified to
```
return this.owner.$query()
    .childQueryOf(builder)
    .patch(patch)
    .return(inserted);
```

---

I ran tests for this locally, but I want to run them them through Travis. Please feel free to close if this isn't a good idea.