### PR TITLE
Add types for .mixin and .compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/knex": "^0.0.61",
-    "@types/node": "^8.0.28",
+    "@types/node": "^8.0.32",
     "coveralls": "^2.13.1",
     "expect.js": "^0.3.1",
     "fs-extra": "3.0.1",
@@ -70,6 +70,6 @@
     "pg": "^6.2.2",
     "sqlite3": "^3.1.8",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.2"
+    "typescript": "^2.5.3"
   }
 }

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -217,7 +217,7 @@ const rowsEager: Promise<Person[]> = Person.query()
   .eagerAlgorithm(Person.NaiveEagerAlgorithm)
   .eager('foo.bar');
 
-const rowsPage: Promise<{ total: number, results: Person[] }> = Person.query().page(1, 10);
+const rowsPage: Promise<{ total: number; results: Person[] }> = Person.query().page(1, 10);
 
 const rowsRange: Promise<objection.Page<Person>> = Person.query().range(1, 10);
 
@@ -390,9 +390,7 @@ Person.query().whereIn('firstName', whereSubQuery);
 Person.query().where('foo', whereSubQuery);
 Person.query().whereExists(whereSubQuery);
 Person.query().where(builder => {
-  builder
-    .whereBetween('age', [30, 40])
-    .orWhereIn('lastName', whereSubQuery);
+  builder.whereBetween('age', [30, 40]).orWhereIn('lastName', whereSubQuery);
 });
 
 // RawBuilder:
@@ -456,6 +454,10 @@ function takesComment(_: Comment) {
   //
 }
 
+// (these thunks provide variable scoping to isolate examples)
+
+// .compose tests:
+
 () => {
   const AnimalPerson = objection.compose(Animal, Person);
   const o = new AnimalPerson();
@@ -480,6 +482,8 @@ function takesComment(_: Comment) {
   takesComment(o);
 };
 
+// .mixin tests:
+
 () => {
   const AnimalPerson = objection.mixin(Animal, [Person]);
   const o = new AnimalPerson();
@@ -502,4 +506,22 @@ function takesComment(_: Comment) {
   takesAnimal(o);
   takesMovie(o);
   takesComment(o);
+};
+
+() => {
+  class Plugin {
+    plug() {
+      //
+    }
+  }
+  class PluggablePerson extends objection.mixin(objection.Model, [Person, Plugin]) {
+    unplug() {
+      //
+    }
+  }
+  const pp = new PluggablePerson();
+  pp.plug();
+  pp.$knex();
+  pp.firstName = 'bob';
+  pp.unplug();
 };

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -162,7 +162,7 @@ qb = qb.increment('column_name', 2);
 qb = qb.decrement('column_name', 1);
 qb = qb.select('column1');
 qb = qb.select('column1', 'column2', 'column3');
-qb = qb.select(['column1', 'column2'])
+qb = qb.select(['column1', 'column2']);
 qb = qb.forUpdate();
 qb = qb.as('column_name');
 qb = qb.column('column_name');
@@ -217,11 +217,9 @@ const rowsEager: Promise<Person[]> = Person.query()
   .eagerAlgorithm(Person.NaiveEagerAlgorithm)
   .eager('foo.bar');
 
-const rowsPage: Promise<{total: number, results: Person[]}> = Person.query()
-  .page(1, 10)
+const rowsPage: Promise<{ total: number, results: Person[] }> = Person.query().page(1, 10);
 
-const rowsRange: Promise<objection.Page<Person>> = Person.query()
-  .range(1, 10);
+const rowsRange: Promise<objection.Page<Person>> = Person.query().range(1, 10);
 
 // `retuning` should change the return value from number to T[]
 const rowsUpdateReturning: Promise<Person[]> = Person.query()
@@ -236,20 +234,20 @@ const rowPatchReturningFirst: Promise<Person | undefined> = Person.query()
 // `retuning` should change the return value from number to T[]
 const rowsDeleteReturning: Promise<Person[]> = Person.query()
   .delete()
-  .returning('*')
+  .returning('*');
 
 const rowsDeleteReturningFirst: Promise<Person | undefined> = Person.query()
   .delete()
   .returning('*')
-  .first()
+  .first();
 
 const rowInsertReturning: Promise<Person | undefined> = Person.query()
   .insert({})
-  .returning('*')
+  .returning('*');
 
 const rowsInsertReturning: Promise<Person[]> = Person.query()
   .insert([{}])
-  .returning('*')
+  .returning('*');
 
 // non-wrapped methods:
 
@@ -394,7 +392,7 @@ Person.query().whereExists(whereSubQuery);
 Person.query().where(builder => {
   builder
     .whereBetween('age', [30, 40])
-    .orWhereIn('lastName', whereSubQuery)
+    .orWhereIn('lastName', whereSubQuery);
 });
 
 // RawBuilder:
@@ -422,8 +420,8 @@ Person.query()
 
 // LiteralBuilder:
 Person.query().where(ref('Model.jsonColumn:details'), '=', lit({ name: 'Jennifer', age: 29 }));
-Person.query().where('age', '>', lit(10))
-Person.query().where('firstName', lit('Jennifer').castText())
+Person.query().where('age', '>', lit(10));
+Person.query().where('firstName', lit('Jennifer').castText());
 
 // .query, .$query, and .$relatedQuery can take a Knex instance to support
 // multitenancy
@@ -431,4 +429,77 @@ Person.query().where('firstName', lit('Jennifer').castText())
 const peep123: Promise<Person | undefined> = BoundPerson.query(k).findById(123);
 
 new Person().$query(k).execute();
-new Person().$relatedQuery("pets", k).execute();
+new Person().$relatedQuery('pets', k).execute();
+
+async function asyncExamples(value: number | undefined) {
+  // verify: @drew-r: QueryBuilder.resultSize(): Promise<Number> but
+  // objection returns a string for this as far as I can tell.
+  const resultSize: number = await Person.query().resultSize();
+
+  // verify: @drew-r: We also can't use undefined values in where followed
+  // by skipUndefined because of the way Value works.
+  const person: Person | undefined = await Person.query()
+    .where('id', value)
+    .first();
+}
+
+function takesPerson(_: Person) {
+  //
+}
+function takesAnimal(_: Animal) {
+  //
+}
+function takesMovie(_: Movie) {
+  //
+}
+function takesComment(_: Comment) {
+  //
+}
+
+() => {
+  const AnimalPerson = objection.compose(Animal, Person);
+  const o = new AnimalPerson();
+  takesPerson(o);
+  takesAnimal(o);
+};
+
+() => {
+  const AnimalPersonMovie = objection.compose(Animal, Person, Movie);
+  const o = new AnimalPersonMovie();
+  takesPerson(o);
+  takesAnimal(o);
+  takesMovie(o);
+};
+
+() => {
+  const AnimalPersonMovieComment = objection.compose(Animal, Person, Movie, Comment);
+  const o = new AnimalPersonMovieComment();
+  takesPerson(o);
+  takesAnimal(o);
+  takesMovie(o);
+  takesComment(o);
+};
+
+() => {
+  const AnimalPerson = objection.mixin(Animal, [Person]);
+  const o = new AnimalPerson();
+  takesPerson(o);
+  takesAnimal(o);
+};
+
+() => {
+  const AnimalPersonMovie = objection.mixin(Animal, [Person, Movie]);
+  const o = new AnimalPersonMovie();
+  takesPerson(o);
+  takesAnimal(o);
+  takesMovie(o);
+};
+
+() => {
+  const AnimalPersonMovieComment = objection.mixin(Animal, [Person, Movie, Comment]);
+  const o = new AnimalPersonMovieComment();
+  takesPerson(o);
+  takesAnimal(o);
+  takesMovie(o);
+  takesComment(o);
+};

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -48,7 +48,7 @@ declare namespace Objection {
     // See https://www.typescriptlang.org/docs/handbook/generics.html#using-class-types-in-generics
     <A>(
       a: new () => A
-    ): { new (): A};
+    ): { new (): A };
 
     <A, B>(
       a: new () => A,

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -11,6 +11,8 @@ declare namespace Objection {
   const lit: LiteralBuilder;
   const raw: knex.RawBuilder;
   const ref: ReferenceBuilder;
+  const compose: Compose;
+  const mixin: Mixin;
 
   interface LiteralObject {
     [key: string]: Value
@@ -41,6 +43,128 @@ declare namespace Objection {
   export interface Literal extends Castable {}
 
   export interface Reference extends Castable {}
+
+  export interface Compose {
+    // See https://www.typescriptlang.org/docs/handbook/generics.html#using-class-types-in-generics
+    <A>(
+      a: new () => A
+    ): { new (): A};
+
+    <A, B>(
+      a: new () => A,
+      b: new () => B
+    ): { new (): A & B };
+
+    <A, B, C>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C
+    ): { new (): A & B & C };
+
+    <A, B, C, D>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C,
+      d: new () => D
+    ): { new (): A & B & C & D };
+
+    <A, B, C, D, E>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C,
+      d: new () => D,
+      e: new () => E
+    ): { new (): A & B & C & D & E };
+
+    <A, B, C, D, E, F>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C,
+      d: new () => D,
+      e: new () => E,
+      f: new () => F
+    ): { new (): A & B & C & D & E & F };
+
+    <A, B, C, D, E, F, G>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C,
+      d: new () => D,
+      e: new () => E,
+      f: new () => F,
+      g: new () => G
+    ): { new (): A & B & C & D & E & F & G };
+
+    <A, B, C, D, E, F, G, H>(
+      a: new () => A,
+      b: new () => B,
+      c: new () => C,
+      d: new () => D,
+      e: new () => E,
+      f: new () => F,
+      g: new () => G,
+      h: new () => H
+    ): { new (): A & B & C & D & E & F & G & H };
+  }
+  export interface Mixin {
+    // See https://www.typescriptlang.org/docs/handbook/generics.html#using-class-types-in-generics
+    <M, A>(
+      m: new () => M,
+      arr: [new () => A]
+    ): { 
+      new (): M & A;
+    };
+
+    <M, A, B>(
+      m: new () => M,
+      arr: [new () => A, new () => B]
+    ): {
+      new (): M & A & B;
+    };
+
+    <M, A, B, C>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C]
+    ): {
+      new (): M & A & B & C;
+    };
+
+    <M, A, B, C, D>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C, new () => D]
+    ): {
+      new (): M & A & B & C & D;
+    };
+
+    <M, A, B, C, D, E>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C, new () => D, new () => E]
+    ): {
+      new (): M & A & B & C & D & E;
+    };
+
+    <M, A, B, C, D, E, F>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C, new () => D, new () => E, new () => F]
+    ): {
+      new (): M & A & B & C & D & E & F;
+    };
+
+    <M, A, B, C, D, E, F, G>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C, new () => D, new () => E, new () => F, new () => G]
+    ): {
+      new (): M & A & B & C & D & E & F & G;
+    };
+
+    <M, A, B, C, D, E, F, G, H>(
+      m: new () => M,
+      arr: [new () => A, new () => B, new () => C, new () => D, new () => E, new () => F, new () => G, new () => H]
+    ): {
+      new (): M & A & B & C & D & E & F & G & H;
+    };
+  }
+
 
   export interface Page<T> {
     total: number;
@@ -282,7 +406,7 @@ declare namespace Objection {
     static query<T>(this: { new(): T }, trxOrKnex?: Transaction | knex): QueryBuilder<T>;
     static knex(knex?: knex): knex;
     static formatter(): any; // < the knex typings punts here too
-    static knexQuery<T>(this: { new(): T }): knex.QueryBuilder;
+    static knexQuery(): knex.QueryBuilder;
     static bindKnex<T>(this: T, knex: knex): T;
     static bindTransaction<T>(this: T, transaction: Transaction): T;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@types/bluebird@*":
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.10.tgz#c4b09b7ffa4b1b2baec2b03eca8618687099acb0"
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.14.tgz#370ca8814b902da06f24115a23ea40c60610878c"
 
 "@types/knex@^0.0.61":
   version "0.0.61"
@@ -13,13 +13,13 @@
     "@types/bluebird" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^8.0.28":
-  version "8.0.28"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
+"@types/node@*", "@types/node@^8.0.32":
+  version "8.0.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.32.tgz#869a716538b6eec65ab3893f183d557be3cda206"
 
 abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 abbrev@1.0.x:
   version "1.0.9"
@@ -33,8 +33,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.1.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -62,8 +62,8 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
 aproba@^1.0.3:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -156,8 +156,8 @@ block-stream@*:
     inherits "~2.0.0"
 
 bluebird@^3.4.6, bluebird@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 boom@2.x.x:
   version "2.10.1"
@@ -270,8 +270,8 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
 coveralls@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.1.tgz#d70bb9acc1835ec4f063ff9dac5423c17b11f178"
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.3.tgz#9ad7c2ae527417f361e8b626483f48ee92dd2bc7"
   dependencies:
     js-yaml "3.6.1"
     lcov-parse "0.0.10"
@@ -291,19 +291,21 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.8, debug@^2.1.3, debug@^2.2.0:
+debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.1.3, debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-deep-equal@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -312,17 +314,6 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
-  dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
-
-defined@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -351,24 +342,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-es-abstract@^1.5.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  dependencies:
-    is-callable "^1.1.1"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
@@ -472,12 +445,6 @@ flagged-respawn@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5"
 
-for-each@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
-  dependencies:
-    is-function "~1.0.0"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -487,10 +454,6 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
-
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -536,10 +499,6 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
-
-function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -612,7 +571,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1, glob@~7.1.2:
+glob@^7.0.5, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -695,13 +654,7 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has@^1.0.1, has@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
-
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -755,14 +708,6 @@ is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
-is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -786,10 +731,6 @@ is-fullwidth-code-point@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   dependencies:
     number-is-nan "^1.0.0"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -829,16 +770,6 @@ is-primitive@^2.0.0:
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  dependencies:
-    has "^1.0.1"
-
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -905,8 +836,8 @@ js-yaml@3.6.1:
     esprima "^2.6.0"
 
 js-yaml@3.x:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1117,7 +1048,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.2.0, minimist@~1.2.0:
+minimist@1.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1136,8 +1067,8 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 mocha@^3.4.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.1.tgz#9b6d13ac1ccf957edd16f2e439055734b1b60391"
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -1169,18 +1100,18 @@ nan@~2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
-node-pre-gyp@~0.6.37:
-  version "0.6.37"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
+node-pre-gyp@~0.6.38:
+  version "0.6.38"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz#e92a20f83416415bb4086f6d1fb78b3da73d113d"
   dependencies:
+    hawk "3.1.3"
     mkdirp "^0.5.1"
     nopt "^4.0.1"
     npmlog "^4.0.2"
     rc "^1.1.7"
-    request "^2.81.0"
+    request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tape "^4.6.3"
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
@@ -1227,14 +1158,6 @@ object-assign@4.1.0:
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-object-inspect@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
-
-object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -1492,7 +1415,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.81.0:
+request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -1530,17 +1453,11 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@~1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
-
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  dependencies:
-    through "~2.3.4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1549,8 +1466,8 @@ right-align@^0.1.1:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -1607,11 +1524,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sqlite3@^3.1.8:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.10.tgz#b1f10dfc5d487b079fda2f34fbf60cbaf6d92ad3"
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
   dependencies:
     nan "~2.7.0"
-    node-pre-gyp "~0.6.37"
+    node-pre-gyp "~0.6.38"
 
 sqlstring@2.2.0:
   version "2.2.0"
@@ -1638,14 +1555,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string.prototype.trim@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.0"
-    function-bind "^1.0.2"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -1687,24 +1596,6 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
-tape@^4.6.3:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
-  dependencies:
-    deep-equal "~1.0.1"
-    defined "~1.0.0"
-    for-each "~0.3.2"
-    function-bind "~1.1.0"
-    glob "~7.1.2"
-    has "~1.0.1"
-    inherits "~2.0.3"
-    minimist "~1.2.0"
-    object-inspect "~1.3.0"
-    resolve "~1.4.0"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.1.2"
-    through "~2.3.8"
-
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
@@ -1726,7 +1617,7 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-through@2, through@~2.3.4, through@~2.3.8:
+through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -1737,8 +1628,8 @@ tildify@~1.0.0:
     user-home "^1.0.0"
 
 tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
 
@@ -1762,8 +1653,8 @@ tslint@^5.7.0:
     tsutils "^2.8.1"
 
 tsutils@^2.8.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.2.tgz#2c1486ba431260845b0ac6f902afd9d708a8ea6a"
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.11.2.tgz#6013601e36fa14ff958413e541d427fb8c6ac341"
   dependencies:
     tslib "^1.7.1"
 
@@ -1787,9 +1678,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
+typescript@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Addresses https://github.com/Vincit/objection.js/issues/536

* added `.compose` and `.mixin` support. YIKES THAT IS SOME UGLY COPYPASTA but that's how you do it, afaik.
* removed unnecessary `this` capture from `.knexQuery` typing
* updated typings and typescript. @koskimas you might want to upgrade the other root package.json deps, many are not on the latest version (`yarn upgrade --latest`).
* added missing semis that tslint grumped about
* added assertions based on @drew-r's concerns (Drew, could you check this diff, because it seems like things are working as expected? I think I'm misunderstanding you, perhaps?)