### PR TITLE
Add typings for .throwIfNotFound

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-travis": "istanbul --config=.istanbul.yml cover _mocha -- --slow 100 --timeout 60000 --reporter spec --recursive tests && npm run test-typings",
     "test-bail": "mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --bail",
     "test-opt": "mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --bail --trace_opt --trace_deopt --trace_inlining",
-    "test-typings": "tsc --noEmit",
+    "test-typings": "tsc",
     "coveralls": "cat ./testCoverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "perf": "mocha --slow 60000 --timeout 60000 --reporter spec --recursive perf",
     "perf-opt": "mocha --slow 60000 --timeout 60000 --reporter spec --recursive perf --trace_opt --trace_deopt --trace_inlining"

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -179,6 +179,22 @@ let qb: objection.QueryBuilder<Person> = BoundPerson.query().where(
   'foo'
 );
 
+// QueryBuilder.throwIfNotFound makes an option query return exactly one:
+
+async () => {
+  const q = () => Person.query().findOne({lastName});
+  takesMaybePerson(await q());
+  takesPerson(await q().throwIfNotFound());
+};
+
+// QueryBuilder.throwIfNotFound does nothing for array results:
+
+async () => {
+  const q = () => Person.query().where({lastName});
+  takesPeople(await q());
+  takesPeople(await q().throwIfNotFound());
+};
+
 // Note that the QueryBuilder chaining done in this file
 // is done to verify that the return value is assignable to a QueryBuilder
 // (fewer characters than having each line `const qbNNN: QueryBuilder =`):

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -385,36 +385,40 @@ declare namespace Objection {
     static forClass<M extends Model>(modelClass: ModelClass<M>): QueryBuilder<M>;
   }
 
+  export interface ThrowIfNotFound {
+    throwIfNotFound(): this;
+  }
+
   /**
    * QueryBuilder with one expected result
    */
-  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, Promise<T> { }
+  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> { }
 
   /**
    * Query builder for update operations
    */
-  export interface QueryBuilderUpdate<T> extends QueryBuilderBase<T>, Promise<number> {
-    returning(columns: string | string[]): QueryBuilder<T>
+  export interface QueryBuilderUpdate<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<number> {
+    returning(columns: string | string[]): QueryBuilder<T>;
   }
 
   /**
    * Query builder for delete operations
    */
-  export interface QueryBuilderDelete<T> extends QueryBuilderBase<T>, Promise<number> {
-    returning(columns: string | string[]): QueryBuilder<T>
+  export interface QueryBuilderDelete<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<number> {
+    returning(columns: string | string[]): QueryBuilder<T>;
   }
 
   /**
    * Query builder for batch insert operations
    */
-  export interface QueryBuilderInsert<T> extends QueryBuilderBase<T>, Promise<T[]> {
+  export interface QueryBuilderInsert<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> {
     returning(columns: string | string[]): this;
   }
 
   /**
    * Query builder for single insert operations
    */
-  export interface QueryBuilderInsertSingle<T> extends QueryBuilderBase<T>, Promise<T> {
+  export interface QueryBuilderInsertSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> {
     returning(columns: string | string[]): this;
   }
 
@@ -422,26 +426,30 @@ declare namespace Objection {
    * QueryBuilder with zero or one expected result
    * (Using the Scala `Option` terminology)
    */
-  export interface QueryBuilderOption<T> extends QueryBuilderBase<T>, Promise<T | undefined> { }
+  export interface QueryBuilderOption<T> extends QueryBuilderBase<T>, Promise<T | undefined> {
+    throwIfNotFound(): QueryBuilderSingle<T>;
+  }
 
   /**
    * QueryBuilder with zero or more expected results
    */
-  export interface QueryBuilder<T> extends QueryBuilderBase<T>, Promise<T[]> { }
+  export interface QueryBuilder<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> { 
+  }
 
   /**
    * QueryBuilder with a page result.
    */
-  export interface QueryBuilderPage<T> extends QueryBuilderBase<T>, Promise<Page<T>> { }
+  export interface QueryBuilderPage<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<Page<T>> { 
+  }
 
   interface Insert<T> {
-    (modelsOrObjects?: Array<Partial<T>>): QueryBuilderInsert<T>;
+    (modelsOrObjects?: Partial<T>[]): QueryBuilderInsert<T>;
     (modelOrObject?: Partial<T>): QueryBuilderInsertSingle<T>;
     (): this;
   }
 
   interface Upsert<T> {
-    (modelsOrObjects?: Array<Partial<T>>, options?: UpsertOptions): QueryBuilder<T>;
+    (modelsOrObjects?: Partial<T>[], options?: UpsertOptions): QueryBuilder<T>;
     (modelOrObject?: Partial<T>, options?: UpsertOptions): QueryBuilderSingle<T>;
   }
 


### PR DESCRIPTION
Closes https://github.com/Vincit/objection.js/issues/533

* added example tests and typings. This required **every** QueryBuilder flavor to be touched, as `QueryBuilderOption` needed to return a `QueryBuilderSingle`, but every other subclass needed to return `this`. Should we add a new `QueryBuilderArray` base class? Will there be more of these sorts of methods?
* removed `--noEmit` from package.json test-typings script. It wasn't needed, as the `tsconfig.json` already has `noEmit: true`
* replaced `Array<Something>` with `Something[]`, as is preferred by the TypeScript style guide (generics support isn't as solid as arrays)