### PR TITLE
Simplify parseValidationError()

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -123,18 +123,11 @@ function parseValidationError(errors, modelClass) {
     let key = error.dataPath.substring(1);
 
     if (!key) {
-      let match = /should have required property '(.+)'/.exec(error.message);
-      if (match && match.length > 1) {
-        key = match[1];
+      const params = error.params;
+      key = params && (params.missingProperty || params.additionalProperty);
+      if (!key) {
+        key = (index++).toString();
       }
-    }
-
-    if (!key && error.params && error.params.additionalProperty) {
-      key = error.params.additionalProperty;
-    }
-
-    if (!key) {
-      key = (index++).toString();
     }
 
     errorHash[key] = [{


### PR DESCRIPTION
This is a simple PR: There is no need to parse `error.message`, we can use `error.params.missingProperty` instead.

`tests\unit\model\Model.js` has tests for this, and they are all still passing with this change.