### PR TITLE
Use model name or table name for validator caching

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -71,7 +71,7 @@ class AjvValidator extends Validator {
     // Optimization for the common case where jsonSchema is never modified.
     // In that case we don't need to call the costly JSON.stringify.
     const key = jsonSchema === ModelClass.getJsonSchema()
-      ? 'default'
+      ? ModelClass.name || ModelClass.tableName
       : serialize(jsonSchema);
 
     let validators = this.cache[key];


### PR DESCRIPTION
This simple change allows one AjvValidator instance to be shared across multiple models.
See #549 for further discussions.