### PR TITLE
Add support for AjvValidator's options.passContext

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -55,7 +55,13 @@ class AjvValidator extends Validator {
       json = cloneDeep(json);
     }
 
-    validator(json);
+    // Allow Ajv's options.passContext to be used in order to receive the model
+    // instance as `this` inside custom keywords and formats.
+    if (this.ajvOptions.passContext) {
+      validator.call(model, json);
+    } else {
+      validator(json);
+    }
 
     if (validator.errors) {
       throw parseValidationError(validator.errors, model.constructor);


### PR DESCRIPTION
This PR adds suppor for `options.passContext` in Ajv. Setting it to `true` allows custom keywords and formats to receive the model instance as `this` inside their handlers.

If you agree to merge this in, I will work on writing unit tests for the functionality before the merge.