### PR TITLE
Support insertMissing option in upsertGraph() for root models

### DIFF
--- a/lib/queryBuilder/graphUpserter/UpsertGraph.js
+++ b/lib/queryBuilder/graphUpserter/UpsertGraph.js
@@ -73,14 +73,7 @@ class UpsertGraph {
       })
       // Don't use mergeContext here so that the added stuff doesn't leak
       // to other queries.
-      .context(context)
-      .then(result => {
-        if (result.length !== rootIds.length) {
-          throw new Error(`one or more of the root models (ids=[${rootIds.join(', ')}]) were not found`);
-        } else {
-          return result;
-        }
-      });
+      .context(context);
   }
 
   buildGraph(current) {

--- a/lib/queryBuilder/graphUpserter/UpsertNode.js
+++ b/lib/queryBuilder/graphUpserter/UpsertNode.js
@@ -92,11 +92,14 @@ function getType(node) {
         return UpsertNodeType.Insert;
       }
     } else {
+      const parent = node.parentNode;
       throw new Error([
-        `model (id=${node.upsertModel.$id()}) is not a child of model (id=${node.parentNode.upsertModel.$id()}).`,
-        `If you want to relate it, use the relate: true option.`,
+        parent
+          ? `model (id=${node.upsertModel.$id()}) is not a child of model (id=${parent.upsertModel.$id()}). `
+          : `root model (id=${node.upsertModel.$id()}) does not exist. `,
+        parent ? `If you want to relate it, use the relate: true option. ` : '',
         `If you want to insert it with an id, use the insertMissing: true option`
-      ].join(' '));
+      ].join(''));
     }
   } else if (node.upsertModel !== null && node.currentModel === null) {
     if (hasOption(node, 'noInsert')) {


### PR DESCRIPTION
As discussed on [Gitter](https://gitter.im/Vincit/objection.js?at=59ec719532e080696e0eb50a), the `insertMissing` option in `upsertGraph()` currently does not work for root models.

This patch addresses it by leveraging the same mechanism already in place for child models.

I've started adding unit tests for `insertMissing: true` on root models, but am not sure if I'm doing it right, and also wanted to first check if this fix is the right way to go about the issue.