### PR TITLE
Support named filters on relations

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -340,14 +340,25 @@ function createRelationProperty(ctx, refString, propName) {
 
 function parseModify(ctx) {
   const mapping = ctx.mapping;
+  const value = mapping.modify || mapping.filter;
+  let modify;
 
-  let modify = mapping.modify || mapping.filter;
-  let type = typeof modify;
-
-  if (modify && type === 'object') {
-    const obj = modify;
-    modify = (qb) => qb.where(obj);
-  } else if (type !== 'function') {
+  if (value) {
+    const type = typeof value;
+    if (type === 'object') {
+      modify = (qb) => qb.where(value);
+    } else if (type === 'function') {
+      modify = value;
+    } else if (type === 'string') {
+      const namedFilters = ctx.relatedModelClass.namedFilters;
+      modify = namedFilters && namedFilters[value];
+      if (!modify) {
+        throw ctx.createError(`Could not find filter "${value}".`);
+      }
+    } else {
+      throw ctx.createError(`Unable to determine modify function from provided value: "${value}".`);
+    }
+  } else {
     modify = () => {};
   }
 

--- a/tests/unit/relations/HasManyRelation.js
+++ b/tests/unit/relations/HasManyRelation.js
@@ -48,6 +48,12 @@ describe('HasManyRelation', () => {
       static get tableName() {
         return 'RelatedModel';
       }
+
+      static get namedFilters() {
+        return {
+          namedFilter: builder => builder.where('filteredProperty', true)
+        }
+      }
     };
 
     OwnerModel.knex(mockKnex);
@@ -251,6 +257,39 @@ describe('HasManyRelation', () => {
         expect(executedQueries[0]).to.equal(builder.toString());
         expect(executedQueries[0]).to.equal(builder.toSql());
         expect(executedQueries[0]).to.equal('select "RelatedModel".* from "RelatedModel" where "RelatedModel"."ownerId" in (666) and "someColumn" = \'foo\' and "name" = \'Teppo\' or "age" > 60');
+      });
+    });
+
+    it('should support named filters', () => {
+      createModifiedRelation('namedFilter');
+
+      let owner = OwnerModel.fromJson({oid: 666});
+      let expectedResult = [
+        {a: 1, ownerId: 666},
+        {a: 2, ownerId: 666}
+      ];
+
+      mockKnexQueryResults = [expectedResult];
+
+      let builder = QueryBuilder
+        .forClass(RelatedModel)
+        .where('name', 'Teppo')
+        .orWhere('age', '>', 60)
+        .findOperationFactory(builder => {
+          return relation.find(builder, [owner]);
+        });
+
+      return builder.then(result => {
+        expect(result).to.have.length(2);
+        expect(result).to.eql(expectedResult);
+        expect(owner.nameOfOurRelation).to.eql(expectedResult);
+        expect(result[0]).to.be.a(RelatedModel);
+        expect(result[1]).to.be.a(RelatedModel);
+
+        expect(executedQueries).to.have.length(1);
+        expect(executedQueries[0]).to.equal(builder.toString());
+        expect(executedQueries[0]).to.equal(builder.toSql());
+        expect(executedQueries[0]).to.equal('select "RelatedModel".* from "RelatedModel" where "RelatedModel"."ownerId" in (666) and "filteredProperty" = true and "name" = \'Teppo\' or "age" > 60');
       });
     });
 

--- a/tests/unit/relations/ManyToManyRelation.js
+++ b/tests/unit/relations/ManyToManyRelation.js
@@ -51,6 +51,12 @@ describe('ManyToManyRelation', () => {
       static get tableName() {
         return 'RelatedModel';
       }
+
+      static get namedFilters() {
+        return {
+          namedFilter: builder => builder.where('filteredProperty', true)
+        }
+      }
     };
 
     JoinModel = class JoinModel extends Model {
@@ -604,6 +610,47 @@ describe('ManyToManyRelation', () => {
       });
     });
 
+    // TODO expectedResult array is changed in-place and the items in it are replaced with model instances. SHOULD FIX THAT!
+    it('should support named filters', () => {
+      createModifiedRelation('namedFilter');
+
+      let owner = OwnerModel.fromJson({oid: 666});
+      let expectedResult = [
+        {a: 1, objectiontmpjoin0: 666},
+        {a: 2, objectiontmpjoin0: 666}
+      ];
+
+      mockKnexQueryResults = [expectedResult];
+
+      let builder = QueryBuilder
+        .forClass(RelatedModel)
+        .where('name', 'Teppo')
+        .orWhere('age', '>', 60)
+        .findOperationFactory(function () {
+          return relation.find(this, [owner]);
+        });
+
+      return builder.then(result => {
+        expect(result).to.have.length(2);
+        expect(result).to.eql(expectedResult);
+        expect(owner.nameOfOurRelation).to.eql(expectedResult);
+        expect(result[0]).to.be.a(RelatedModel);
+        expect(result[1]).to.be.a(RelatedModel);
+
+        expect(executedQueries).to.have.length(1);
+        expect(executedQueries[0]).to.equal(builder.toString());
+        expect(executedQueries[0]).to.equal(builder.toSql());
+        expect(executedQueries[0]).to.equal([
+          'select "RelatedModel".*, "JoinModel"."ownerId" as "objectiontmpjoin0"',
+          'from "RelatedModel"',
+          'inner join "JoinModel" on "RelatedModel"."rid" = "JoinModel"."relatedId"',
+          'where "JoinModel"."ownerId" in (666)',
+          'and "filteredProperty" = true',
+          'and "name" = \'Teppo\'',
+          'or "age" > 60'
+        ].join(' '));
+      });
+    });
   });
 
   describe('insert', () => {


### PR DESCRIPTION
It would be nice if named filters could also be used on relations. This PR addresses that, by looking them up on the related model class.