### PR TITLE
Cleared up babel plugins and presets in express-es7-examples

### DIFF
--- a/examples/express-es7/README.md
+++ b/examples/express-es7/README.md
@@ -8,13 +8,6 @@ npm install
 npm start
 ```
 
-Note that starting from 0.8.0 objection uses native ES2015 classes and no longer supports
-legacy ES5 classes. This also means Babel generated ES5 code. For this reason we need to
-omit the `babel-plugin-transform-es2015-classes` plugin. There is no way to omit plugins
-from presets. That's why the package.json explicitly lists all plugins in Babel `es2015`
-preset __except__ `babel-plugin-transform-es2015-classes`.
-
-
 `example-requests.sh` file contains a bunch of `curl` commands for you to start playing with the REST API:
 
 ```sh

--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -3,45 +3,26 @@
   "version": "0.8.0",
   "description": "Objection.js express ES7 example",
   "main": "app.js",
-
   "scripts": {
     "migrate": "knex migrate:latest",
     "build": "babel src -d build",
     "start": "npm run build && npm run migrate && node build/app"
   },
-
   "babel": {
     "presets": [
-      "stage-0"
-    ],
-    "plugins": [
-      "check-es2015-constants",
-      "transform-es2015-arrow-functions",
-      "transform-es2015-block-scoped-functions",
-      "transform-es2015-block-scoping",
-      "transform-es2015-computed-properties",
-      "transform-es2015-destructuring",
-      "transform-es2015-duplicate-keys",
-      "transform-class-properties",
-      "transform-es2015-for-of",
-      "transform-es2015-function-name",
-      "transform-es2015-literals",
-      "transform-es2015-modules-commonjs",
-      "transform-es2015-object-super",
-      "transform-es2015-parameters",
-      "transform-es2015-shorthand-properties",
-      "transform-es2015-spread",
-      "transform-es2015-sticky-regex",
-      "transform-es2015-template-literals",
-      "transform-es2015-typeof-symbol",
-      "transform-es2015-unicode-regex",
-      "transform-async-to-generator"
+      [
+        "env",
+        {
+          "targets": {
+            "node": "current"
+          }
+        }
+      ],
+      "stage-1"
     ]
   },
-
   "author": "Sami Koskimäki",
   "license": "MIT",
-
   "dependencies": {
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
@@ -52,30 +33,9 @@
     "objection": "^0.8.0",
     "sqlite3": "^3.1.8"
   },
-
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-check-es2015-constants": "^6.22.0",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-    "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-    "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-    "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-    "babel-plugin-transform-es2015-for-of": "^6.23.0",
-    "babel-plugin-transform-es2015-function-name": "^6.24.1",
-    "babel-plugin-transform-es2015-literals": "^6.22.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
-    "babel-plugin-transform-es2015-object-super": "^6.24.1",
-    "babel-plugin-transform-es2015-parameters": "^6.24.1",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-    "babel-plugin-transform-es2015-spread": "^6.22.0",
-    "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-    "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-    "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-    "babel-plugin-transform-async-to-generator": "^6.24.1"    
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-1": "^6.24.1"
   }
 }


### PR DESCRIPTION
I tried to apply the enhancement described in issue #573 as a first contribution to the project. I added the `env` preset to the `package.json` and removed the explicit plugin imports and it still seems to work.

I also removed the note about the imports in the README.md