### PR TITLE
Add createValidationError() method to AjvValidator

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -68,10 +68,15 @@ class AjvValidator extends Validator {
     }
 
     if (validator.errors) {
-      throw parseValidationError(validator.errors, model.constructor);
+      throw this.createValidationError(model.constructor, validator.errors);
     }
 
     return json;
+  }
+
+  createValidationError(modelClass, errors) {
+    const errorHash = parseValidationError(errors, modelClass);
+    return modelClass.createValidationError(errorHash);
   }
 
   getValidator(ModelClass, jsonSchema, skipRequired) {
@@ -150,7 +155,7 @@ function parseValidationError(errors, modelClass) {
     ];
   }
 
-  return modelClass.createValidationError(errorHash);
+  return errorHash;
 }
 
 function hasDefaults(obj) {


### PR DESCRIPTION
This simple change allows the overriding of the default error parsing behaviour. I could really use this in my app to have more fine-grained control over how validation errors are handled and displayed.