### PR TITLE
Add GitHub templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+This issues database is used to keep track of bugs and new features.
+For questions and support, please visit the Gitter channel instead:
+  https://gitter.im/Vincit/objection.js
+-->
+
+# Description/Steps to reproduce
+
+<!--
+If a feature: A description of the feature.
+If a bug: The steps to reproduce the issue.
+-->
+
+# Link to reproduction test-case
+
+<!--
+Please link to a test-case for reproduction, ideally as a repository with a
+`packages.json` that installs all required dependencies to reduce confusion.
+
+Note: Failure to provide a test-case for reproduction purposes will result in
+the issue being closed.
+-->
+
+# Expected result
+
+<!--
+Also include actual results when reporting a bug.
+-->
+
+# Additional information
+
+<!--
+Please include the type and versions of Operating System, Node, as well as
+the underlying database that the issue is encountered on.
+
+Examples:
+  macOS 10.12.6, Node 8.9.0, PostgreSQL 10.0
+  Windows 10 Pro 10586.962, Node 8.8.1, SQLite 3
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,37 @@
+# Type of issue
 <!--
-This issues database is used to keep track of bugs and new features.
-For questions and support, please visit the Gitter channel instead:
-  https://gitter.im/Vincit/objection.js
+Is this a *bug* report, a *feature* request, or a *question* or request for *support*?
 -->
 
-# Description/Steps to reproduce
+# Description / Steps to reproduce
 
 <!--
-If a feature: A description of the feature.
-If a bug: The steps to reproduce the issue.
+- For features: A description of the feature.
+- For bugs: The steps to reproduce the issue.
 -->
 
-# Link to reproduction test-case
+# Steps to reproduce / Link to reproduction test-case
 
 <!--
-Please link to a test-case for reproduction, ideally as a repository with a
-`packages.json` that installs all required dependencies to reduce confusion.
+Please link to a test-case for easier reproduction of the issue, for example a RunKit playground or a repository with a `packages.json` that installs all required dependencies and is able to execute the script.
 
-Note: Failure to provide a test-case for reproduction purposes will result in
-the issue being closed.
+Note: Failure to provide a test-case for reproduction purposes will result in the issue being closed.
 -->
 
 # Expected result
-
 <!--
-Also include actual results when reporting a bug.
+Please describe the expected results.
+-->
+
+# Actual result
+<!--
+When reporting a bug, also include the actually encountered results.
 -->
 
 # Additional information
 
 <!--
-Please include the type and versions of Operating System, Node, as well as
-the underlying database that the issue is encountered on.
+Please include the type and versions of Operating System, Node, as well as the underlying database that the issue is encountered on.
 
 Examples:
   macOS 10.12.6, Node 8.9.0, PostgreSQL 10.0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,10 @@ Please list related issues and discussion by using the following syntax:
 ### Checklist
 
 <!--
-- Please mark your choice with an "x" (i.e. [x], see
-https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
+- Please mark your choice with an "x" (i.e. [x], see https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
 - PR's without test coverage will be closed.
 -->
 
 - [ ] New tests added or existing tests modified to cover all changes
-- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
-      and `yarn prettier` has been applied)
+- [ ] Code conforms with the ESLint and Prettier rules (`npm eslint` passes
+      and `npm prettier` has been applied)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+### Description
+
+
+#### Related issues
+
+<!--
+Please list related issues and discussion by using the following syntax:
+
+- Relates to #49
+  (to reference issues in the Objection.js repository)
+- Relates to https://github.com/tgriesser/knex/issues/100
+  (to reference issues in a related repository)
+-->
+
+- Relates to <link_to_referenced_issue>
+
+### Checklist
+
+<!--
+- Please mark your choice with an "x" (i.e. [x], see
+https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
+- PR's without test coverage will be closed.
+-->
+
+- [ ] New tests added or existing tests modified to cover all changes
+- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
+      and `yarn prettier` has been applied)


### PR DESCRIPTION
Based on the suggestion on  [Gitter](https://gitter.im/Vincit/objection.js?at=5a01636032e080696e73e9a0) earlier today, here a proposal of templates for new issues and pull requests, to reduce the amount of time @koskima has to spend answering things that can be avoided or for which the community can help out also.

Please feel free to completely change the wording or reject the PR all together : )