### PR TITLE
Allow AjValidator to return multiple errors per property

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -141,13 +141,15 @@ function parseValidationError(errors, modelClass) {
       }
     }
 
-    errorHash[key] = [
-      {
-        message: error.message,
-        keyword: error.keyword,
-        params: error.params
-      }
-    ];
+    // More than one error can occur for the same key in Ajv, merge them in the array:
+    const array = errorHash[key] || (errorHash[key] = []);
+    // Use unshift instead of push so that the last error ends up at [0],
+    // preserving previous behavior where only the last error was stored.
+    array.unshift({
+      message: error.message,
+      keyword: error.keyword,
+      params: error.params
+    });
   }
 
   return modelClass.createValidationError(errorHash);

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -474,6 +474,36 @@ describe('Model', () => {
       }).to.throwException();
     });
 
+    it('should be capable to return multiple validation errors per property', () => {
+      Model1.jsonSchema = {
+        required: ['a'],
+        properties: {
+          a: {
+            type: 'string',
+            minLength: 5,
+            pattern: '^\\d+$'
+          }
+        }
+      };
+
+      expect(() => {
+        Model1.fromJson({a: 'four'});
+      }).to.throwException(exp => {
+        expect(exp).to.be.a(ValidationError);
+        expect(exp.data).to.have.property('a');
+        expect(exp.data['a']).to.be.a(Array);
+        expect(exp.data['a']).to.have.length(2);
+        expect(exp.data['a'][0]).to.have.property('message');
+        expect(exp.data['a'][0]).to.have.property('keyword');
+        expect(exp.data['a'][0]).to.have.property('params');
+        expect(exp.data['a'][0].keyword).to.equal('pattern');
+        expect(exp.data['a'][1]).to.have.property('message');
+        expect(exp.data['a'][1]).to.have.property('keyword');
+        expect(exp.data['a'][1]).to.have.property('params');
+        expect(exp.data['a'][1].keyword).to.equal('minLength');
+      });
+    });
+
     it('should parse relations into Model instances and remove them from database representation', () => {
       let Model2 = modelClass('Model2');
 


### PR DESCRIPTION
Ajv is capable of returning multiple validation errors per property, but `AjvValidator` currently swallows all but the last error, due to the way `parseValidationError()` is handling errors conversion.

This PR fixes that and adds a unit test for this scenario as well.