### PR TITLE
Typings: fix the return type of QueryBuilder.execute()

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -331,6 +331,29 @@ const rowsInsertReturning: Promise<Person[]> = Person.query()
   .insert([{}])
   .returning('*');
 
+// Executing a query builder should be equivalent to treating it
+// as a promise directly, regardless of query builder return type:
+
+const maybePersonQb = Person.query().findById(1);
+let maybePersonPromise: Promise<Person | undefined> = maybePersonQb;
+maybePersonPromise = maybePersonQb.execute();
+
+const peopleQb = Person.query();
+let peoplePromise: Promise<Person[]> = peopleQb;
+peoplePromise = peopleQb.execute();
+
+const insertQb = Person.query().insert({});
+let insertPromise: Promise<Person> = insertQb;
+insertPromise = insertQb.execute();
+
+const deleteQb = Person.query().delete();
+let deletePromise: Promise<number> = deleteQb;
+deletePromise = deleteQb.execute();
+
+const pageQb = Person.query().page(1, 10);
+let pagePromise: Promise<objection.Page<Person>> = pageQb;
+pagePromise = pageQb.execute();
+
 // non-wrapped methods:
 
 const modelFromQuery: typeof objection.Model = qb.modelClass();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -437,10 +437,14 @@ declare namespace Objection {
     throwIfNotFound(): this;
   }
 
+  export interface Executable<T> extends Promise<T> {
+    execute(): Promise<T>;
+  }
+
   /**
    * QueryBuilder with one expected result
    */
-  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> {
+  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Executable<T> {
     runAfter(fn: (result: T, builder: this) => any): this;
   }
 
@@ -450,7 +454,7 @@ declare namespace Objection {
   export interface QueryBuilderUpdate<T>
     extends QueryBuilderBase<T>,
       ThrowIfNotFound,
-      Promise<number> {
+      Executable<number> {
     returning(columns: string | string[]): QueryBuilder<T>;
     runAfter(fn: (result: number, builder: this) => any): this;
   }
@@ -461,7 +465,7 @@ declare namespace Objection {
   export interface QueryBuilderDelete<T>
     extends QueryBuilderBase<T>,
       ThrowIfNotFound,
-      Promise<number> {
+      Executable<number> {
     returning(columns: string | string[]): QueryBuilder<T>;
     runAfter(fn: (result: number, builder: this) => any): this;
   }
@@ -472,7 +476,7 @@ declare namespace Objection {
   export interface QueryBuilderInsert<T>
     extends QueryBuilderBase<T>,
       ThrowIfNotFound,
-      Promise<T[]> {
+      Executable<T[]> {
     returning(columns: string | string[]): this;
     runAfter(fn: (result: T[], builder: this) => any): this;
   }
@@ -483,7 +487,7 @@ declare namespace Objection {
   export interface QueryBuilderInsertSingle<T>
     extends QueryBuilderBase<T>,
       ThrowIfNotFound,
-      Promise<T> {
+      Executable<T> {
     returning(columns: string | string[]): this;
     runAfter(fn: (result: T, builder: this) => any): this;
   }
@@ -492,7 +496,7 @@ declare namespace Objection {
    * QueryBuilder with zero or one expected result
    * (Using the Scala `Option` terminology)
    */
-  export interface QueryBuilderOption<T> extends QueryBuilderBase<T>, Promise<T | undefined> {
+  export interface QueryBuilderOption<T> extends QueryBuilderBase<T>, Executable<T | undefined> {
     throwIfNotFound(): QueryBuilderSingle<T>;
     runAfter(fn: (result: T | undefined, builder: this) => any): this;
   }
@@ -500,7 +504,7 @@ declare namespace Objection {
   /**
    * QueryBuilder with zero or more expected results
    */
-  export interface QueryBuilder<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> {
+  export interface QueryBuilder<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Executable<T[]> {
     runAfter(fn: (result: T[], builder: this) => any): this;
   }
 
@@ -510,7 +514,7 @@ declare namespace Objection {
   export interface QueryBuilderPage<T>
     extends QueryBuilderBase<T>,
       ThrowIfNotFound,
-      Promise<Page<T>> {}
+      Executable<Page<T>> {}
 
   interface Insert<T> {
     (modelsOrObjects?: Partial<T>[]): QueryBuilderInsert<T>;
@@ -696,7 +700,6 @@ declare namespace Objection {
 
     // We get `then` and `catch` by extending Promise
 
-    execute(): Promise<T>;
     map<V, Result>(mapper: BluebirdMapper<V, Result>): Promise<Result[]>;
     return<V>(returnValue: V): Promise<V>;
     bind(context: any): Promise<T>;


### PR DESCRIPTION
`execute()` turns a query builder into a promise, but the return type of that promise in turn depends on the subtype of query builder. I removed it from `QueryBuilderBase` and added it to each of the subtypes, which should get the return type right. There might be a more clever way to do this, but I couldn't figure anything out and this does work.

Fixes #608.