### PR TITLE
Support for TypeScript 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "knex": "0.x"
   },
   "devDependencies": {
-    "@types/knex": "^0.0.61",
-    "@types/node": "^8.0.33",
+    "@types/knex": "^0.0.65",
+    "@types/node": "^8.0.53",
     "babel-eslint": "^8.0.1",
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
@@ -78,7 +78,7 @@
     "pg": "^6.2.2",
     "prettier": "^1.7.4",
     "sqlite3": "3.1.8",
-    "tslint": "^5.7.0",
-    "typescript": "2.5.3"
+    "tslint": "^5.8.0",
+    "typescript": "^2.6.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
+    "alwaysStrict": true,
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
@@ -10,6 +11,7 @@
     "noImplicitThis": true,
     "noImplicitUseStrict": false,
     "strict": true,
+    "strictFunctionTypes": true,
     "strictNullChecks": true,
     "target": "es6"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
     "member-access": [false],
     "member-ordering": [false],
     "no-console": false,
+    "no-empty": false,
     "no-namespace": [false],
     "no-unused-expression": [false],
     "object-literal-sort-keys": [

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -15,7 +15,7 @@ declare namespace Objection {
   const mixin: Mixin;
 
   interface LiteralObject {
-    [key: string]: Value
+    [key: string]: Value;
   }
 
   export interface LiteralBuilder {
@@ -47,7 +47,7 @@ declare namespace Objection {
   // "{ new(): T }"
   // is from https://www.typescriptlang.org/docs/handbook/generics.html#using-class-types-in-generics
   export interface Constructor<M> {
-    new(...args: any[]): M;
+    new (...args: any[]): M;
   }
 
   export interface Plugin {
@@ -85,7 +85,9 @@ declare namespace Objection {
     message: string;
   }
 
-  export interface RelationMappings { [relationName: string]: RelationMapping; }
+  export interface RelationMappings {
+    [relationName: string]: RelationMapping;
+  }
 
   interface Relation {
     // TODO should this be something other than a tagging interface?
@@ -106,7 +108,7 @@ declare namespace Objection {
 
   export interface RelationMapping {
     relation: Relation;
-    modelClass: typeof Model | string;
+    modelClass: ModelClass<any> | string;
     join: RelationJoin;
     modify?: <T>(queryBuilder: QueryBuilder<T>) => QueryBuilder<T>;
     filter?: <T>(queryBuilder: QueryBuilder<T>) => QueryBuilder<T>;
@@ -147,7 +149,9 @@ declare namespace Objection {
     (queryBuilder: QueryBuilder<T>): void;
   }
 
-  interface FilterExpression<T> { [namedFilter: string]: FilterFunction<T>; }
+  interface FilterExpression<T> {
+    [namedFilter: string]: FilterFunction<T>;
+  }
 
   interface RelationExpressionMethod {
     <T>(relationExpression: RelationExpression): QueryBuilder<T>;
@@ -169,7 +173,9 @@ declare namespace Objection {
 
   type IdOrIds = Id | Ids;
 
-  interface RelationOptions { alias: boolean | string; }
+  interface RelationOptions {
+    alias: boolean | string;
+  }
 
   interface JoinRelation {
     <T>(relationName: string, opt?: RelationOptions): QueryBuilder<T>;
@@ -178,7 +184,10 @@ declare namespace Objection {
   type JsonObjectOrFieldExpression = object | object[] | FieldExpression;
 
   interface WhereJson<T> {
-    (fieldExpression: FieldExpression, jsonObjectOrFieldExpression: JsonObjectOrFieldExpression): QueryBuilder<T>;
+    (
+      fieldExpression: FieldExpression,
+      jsonObjectOrFieldExpression: JsonObjectOrFieldExpression
+    ): QueryBuilder<T>;
   }
 
   interface WhereFieldExpression<T> {
@@ -186,10 +195,7 @@ declare namespace Objection {
   }
 
   interface WhereJsonExpression<T> {
-    (
-      fieldExpression: FieldExpression,
-      keys: string | string[]
-    ): QueryBuilder<T>;
+    (fieldExpression: FieldExpression, keys: string | string[]): QueryBuilder<T>;
   }
 
   interface WhereJsonField<T> {
@@ -215,8 +221,12 @@ declare namespace Objection {
     (err: any, result?: any): void;
   }
 
-  interface Filters<T> { [filterName: string]: (queryBuilder: QueryBuilder<T>) => void; }
-  interface Properties { [propertyName: string]: boolean; }
+  interface Filters<T> {
+    [filterName: string]: (queryBuilder: QueryBuilder<T>) => void;
+  }
+  interface Properties {
+    [propertyName: string]: boolean;
+  }
 
   /**
    * ModelClass is a TypeScript hack to support referencing a Model
@@ -252,7 +262,7 @@ declare namespace Objection {
     query(trxOrKnex?: Transaction | knex): QueryBuilder<M>;
     knex(knex?: knex): knex;
     formatter(): any; // < the knex typings punts here too
-    knexQuery(): knex.QueryBuilder
+    knexQuery(): knex.QueryBuilder;
 
     bindKnex(knex: knex): this;
     bindTransaction(transaction: Transaction): this;
@@ -269,7 +279,11 @@ declare namespace Objection {
       trxOrKnex?: Transaction | knex
     ): Promise<M[]>;
 
-    traverse(filterConstructor: typeof Model, models: Model | Model[], traverser: TraverserFunction): void;
+    traverse(
+      filterConstructor: typeof Model,
+      models: Model | Model[],
+      traverser: TraverserFunction
+    ): void;
     traverse(models: Model | Model[], traverser: TraverserFunction): void;
   }
 
@@ -327,7 +341,11 @@ declare namespace Objection {
       trxOrKnex?: Transaction | knex
     ): Promise<T[]>;
 
-    static traverse(filterConstructor: typeof Model, models: Model | Model[], traverser: TraverserFunction): void;
+    static traverse(
+      filterConstructor: typeof Model,
+      models: Model | Model[],
+      traverser: TraverserFunction
+    ): void;
     static traverse(models: Model | Model[], traverser: TraverserFunction): void;
 
     $id(): any;
@@ -362,9 +380,16 @@ declare namespace Objection {
      * indicate the type (and if it returned Model directly, Partial<Model>
      * guards are worthless)
      */
-    $relatedQuery<M extends Model>(relationName: string, trxOrKnex?: Transaction | knex): QueryBuilder<M>;
+    $relatedQuery<M extends Model>(
+      relationName: string,
+      trxOrKnex?: Transaction | knex
+    ): QueryBuilder<M>;
 
-    $loadRelated<T>(expression: RelationExpression, filters?: Filters<T>, trxOrKnex?: Transaction | knex): QueryBuilderSingle<this>;
+    $loadRelated<T>(
+      expression: RelationExpression,
+      filters?: Filters<T>,
+      trxOrKnex?: Transaction | knex
+    ): QueryBuilderSingle<this>;
 
     $traverse(traverser: TraverserFunction): void;
     $traverse(filterConstructor: this, traverser: TraverserFunction): void;
@@ -392,33 +417,45 @@ declare namespace Objection {
   /**
    * QueryBuilder with one expected result
    */
-  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> { }
+  export interface QueryBuilderSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> {}
 
   /**
    * Query builder for update operations
    */
-  export interface QueryBuilderUpdate<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<number> {
+  export interface QueryBuilderUpdate<T>
+    extends QueryBuilderBase<T>,
+      ThrowIfNotFound,
+      Promise<number> {
     returning(columns: string | string[]): QueryBuilder<T>;
   }
 
   /**
    * Query builder for delete operations
    */
-  export interface QueryBuilderDelete<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<number> {
+  export interface QueryBuilderDelete<T>
+    extends QueryBuilderBase<T>,
+      ThrowIfNotFound,
+      Promise<number> {
     returning(columns: string | string[]): QueryBuilder<T>;
   }
 
   /**
    * Query builder for batch insert operations
    */
-  export interface QueryBuilderInsert<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> {
+  export interface QueryBuilderInsert<T>
+    extends QueryBuilderBase<T>,
+      ThrowIfNotFound,
+      Promise<T[]> {
     returning(columns: string | string[]): this;
   }
 
   /**
    * Query builder for single insert operations
    */
-  export interface QueryBuilderInsertSingle<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T> {
+  export interface QueryBuilderInsertSingle<T>
+    extends QueryBuilderBase<T>,
+      ThrowIfNotFound,
+      Promise<T> {
     returning(columns: string | string[]): this;
   }
 
@@ -433,14 +470,15 @@ declare namespace Objection {
   /**
    * QueryBuilder with zero or more expected results
    */
-  export interface QueryBuilder<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> { 
-  }
+  export interface QueryBuilder<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<T[]> {}
 
   /**
    * QueryBuilder with a page result.
    */
-  export interface QueryBuilderPage<T> extends QueryBuilderBase<T>, ThrowIfNotFound, Promise<Page<T>> { 
-  }
+  export interface QueryBuilderPage<T>
+    extends QueryBuilderBase<T>,
+      ThrowIfNotFound,
+      Promise<Page<T>> {}
 
   interface Insert<T> {
     (modelsOrObjects?: Partial<T>[]): QueryBuilderInsert<T>;
@@ -664,14 +702,21 @@ declare namespace Objection {
       modelClass1: MC1,
       modelClass2: MC2,
       modelClass3: MC3,
-      callback: (boundModel1Class: MC1, boundModel2Class: MC2, boundModel3Class: MC3, trx?: Transaction) => Promise<V>
+      callback: (
+        boundModel1Class: MC1,
+        boundModel2Class: MC2,
+        boundModel3Class: MC3,
+        trx?: Transaction
+      ) => Promise<V>
     ): Promise<V>;
 
-    <MC1 extends ModelClass<any>,
+    <
+      MC1 extends ModelClass<any>,
       MC2 extends ModelClass<any>,
       MC3 extends ModelClass<any>,
       MC4 extends ModelClass<any>,
-      V>(
+      V
+    >(
       modelClass1: MC1,
       modelClass2: MC2,
       modelClass3: MC3,
@@ -685,12 +730,14 @@ declare namespace Objection {
       ) => Promise<V>
     ): Promise<V>;
 
-    <MC1 extends ModelClass<any>,
+    <
+      MC1 extends ModelClass<any>,
       MC2 extends ModelClass<any>,
       MC3 extends ModelClass<any>,
       MC4 extends ModelClass<any>,
       MC5 extends ModelClass<any>,
-      V>(
+      V
+    >(
       modelClass1: MC1,
       modelClass2: MC2,
       modelClass3: MC3,
@@ -719,7 +766,19 @@ declare namespace Objection {
   // to change the signatures to return Objection's typed QueryBuilder wrapper:
   //
 
-  type Value = string | number | boolean | Date | string[] | number[] | boolean[] | Date[] | null | Buffer | Raw | Literal;
+  type Value =
+    | string
+    | number
+    | boolean
+    | Date
+    | string[]
+    | number[]
+    | boolean[]
+    | Date[]
+    | null
+    | Buffer
+    | Raw
+    | Literal;
   type ColumnRef = string | Raw | Reference | QueryBuilder<any>;
   type TableName = string | Raw | Reference | QueryBuilder<any>;
 
@@ -801,20 +860,20 @@ declare namespace Objection {
     orHavingRaw: WhereRaw<T>;
     havingIn: WhereIn<T>;
     orHavingIn: WhereIn<T>;
-    havingNotIn: WhereIn<T>
-    orHavingNotIn: WhereIn<T>
-    havingNull: WhereNull<T>
-    orHavingNull: WhereNull<T>
-    havingNotNull: WhereNull<T>
-    orHavingNotNull: WhereNull<T>
-    havingExists: WhereExists<T>
-    orHavingExists: WhereExists<T>
-    havingNotExists: WhereExists<T>
-    orHavingNotExists: WhereExists<T>
-    havingBetween: WhereBetween<T>
-    orHavingBetween: WhereBetween<T>
-    havingNotBetween: WhereBetween<T>
-    orHavingNotBetween: WhereBetween<T>
+    havingNotIn: WhereIn<T>;
+    orHavingNotIn: WhereIn<T>;
+    havingNull: WhereNull<T>;
+    orHavingNull: WhereNull<T>;
+    havingNotNull: WhereNull<T>;
+    orHavingNotNull: WhereNull<T>;
+    havingExists: WhereExists<T>;
+    orHavingExists: WhereExists<T>;
+    havingNotExists: WhereExists<T>;
+    orHavingNotExists: WhereExists<T>;
+    havingBetween: WhereBetween<T>;
+    orHavingBetween: WhereBetween<T>;
+    havingNotBetween: WhereBetween<T>;
+    orHavingNotBetween: WhereBetween<T>;
 
     // Clear
     clearSelect(): this;
@@ -864,11 +923,19 @@ declare namespace Objection {
 
   interface Join<T> {
     (raw: Raw): QueryBuilder<T>;
-    (tableName: TableName, clause: (this: knex.JoinClause, join: knex.JoinClause) => void): QueryBuilder<T>;
-    (tableName: TableName, columns: { [key: string]: string | number | Raw | Reference }): QueryBuilder<T>;
+    (
+      tableName: TableName,
+      clause: (this: knex.JoinClause, join: knex.JoinClause) => void
+    ): QueryBuilder<T>;
+    (
+      tableName: TableName,
+      columns: {[key: string]: string | number | Raw | Reference}
+    ): QueryBuilder<T>;
     (tableName: TableName, raw: Raw): QueryBuilder<T>;
     (tableName: TableName, column1: ColumnRef, column2: ColumnRef): QueryBuilder<T>;
-    (tableName: TableName, column1: ColumnRef, operator: string, column2: ColumnRef): QueryBuilder<T>;
+    (tableName: TableName, column1: ColumnRef, operator: string, column2: ColumnRef): QueryBuilder<
+      T
+    >;
   }
 
   interface JoinRaw<T> {
@@ -878,7 +945,8 @@ declare namespace Objection {
   interface With<T> extends WithRaw<T>, WithWrapped<T> {}
 
   interface WithRaw<T> {
-    (alias: string, raw: Raw): QueryBuilder<T>;join: knex.JoinClause,
+    (alias: string, raw: Raw): QueryBuilder<T>;
+    join: knex.JoinClause;
     (alias: string, sql: string, bindings?: any): QueryBuilder<T>;
   }
 
@@ -890,8 +958,15 @@ declare namespace Objection {
     (callback: (queryBuilder: QueryBuilder<T>) => void): QueryBuilder<T>;
     (object: object): QueryBuilder<T>;
     (column: ColumnRef, value: Value | Reference | QueryBuilder<any>): QueryBuilder<T>;
-    (column: ColumnRef, operator: string, value: Value | Reference | QueryBuilder<any>): QueryBuilder<T>;
-    (column: ColumnRef, callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void): QueryBuilder<T>;
+    (
+      column: ColumnRef,
+      operator: string,
+      value: Value | Reference | QueryBuilder<any>
+    ): QueryBuilder<T>;
+    (
+      column: ColumnRef,
+      callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void
+    ): QueryBuilder<T>;
   }
 
   interface FindOne<T> {
@@ -901,8 +976,15 @@ declare namespace Objection {
     (sql: string, ...bindings: any[]): QueryBuilderOption<T>;
     (sql: string, bindings: any): QueryBuilderOption<T>;
     (column: ColumnRef, value: Value | Reference | QueryBuilder<any>): QueryBuilderOption<T>;
-    (column: ColumnRef, operator: string, value: Value | Reference | QueryBuilder<any>): QueryBuilderOption<T>;
-    (column: ColumnRef, callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void): QueryBuilderOption<T>;
+    (
+      column: ColumnRef,
+      operator: string,
+      value: Value | Reference | QueryBuilder<any>
+    ): QueryBuilderOption<T>;
+    (
+      column: ColumnRef,
+      callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void
+    ): QueryBuilderOption<T>;
   }
 
   interface WhereRaw<T> extends RawMethod<T> {
@@ -919,7 +1001,10 @@ declare namespace Objection {
 
   interface WhereIn<T> {
     (column: ColumnRef, values: Value[]): QueryBuilder<T>;
-    (column: ColumnRef, callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void): QueryBuilder<T>;
+    (
+      column: ColumnRef,
+      callback: (this: QueryBuilder<T>, queryBuilder: QueryBuilder<T>) => void
+    ): QueryBuilder<T>;
     (column: ColumnRef, query: QueryBuilder<any>): QueryBuilder<T>;
   }
 
@@ -1069,17 +1154,17 @@ declare namespace Objection {
      * Holds simple JSON Schema definitions for
      * referencing from elsewhere.
      */
-    definitions?: { [key: string]: JsonSchema };
+    definitions?: {[key: string]: JsonSchema};
     /**
      * The keys that can exist on the object with the
      * json schema that should validate their value
      */
-    properties?: { [property: string]: JsonSchema };
+    properties?: {[property: string]: JsonSchema};
     /**
      * The key of this object is a regex for which
      * properties the schema applies to
      */
-    patternProperties?: { [pattern: string]: JsonSchema };
+    patternProperties?: {[pattern: string]: JsonSchema};
     /**
      * If the key is present as a property then the
      * string of properties must also be present.
@@ -1087,7 +1172,7 @@ declare namespace Objection {
      * also be valid for the object if the key is
      * present.
      */
-    dependencies?: { [key: string]: JsonSchema | string[] };
+    dependencies?: {[key: string]: JsonSchema | string[]};
 
     /////////////////////////////////////////////////
     // Generic

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -64,8 +64,8 @@ declare namespace Objection {
     // than an identity function type. <M extends typeof Model> retains the
     // model subclass type in the return value, without requiring the user
     // to type the Mixin call.
-    <M extends typeof Model>(modelClass: M, ...plugins: Plugin[]): M;
-    <M extends typeof Model>(modelClass: M, plugins: Plugin[]): M;
+    <MC extends ModelClass<any>>(modelClass: MC, ...plugins: Plugin[]): MC;
+    <MC extends ModelClass<any>>(modelClass: MC, plugins: Plugin[]): MC;
   }
 
   export interface Page<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,16 +59,20 @@
   version "3.5.18"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.18.tgz#6a60435d4663e290f3709898a4f75014f279c4d6"
 
-"@types/knex@^0.0.61":
-  version "0.0.61"
-  resolved "https://registry.yarnpkg.com/@types/knex/-/knex-0.0.61.tgz#3825ec6fe0886237dbce02d1398ae8dfdc19f4b3"
+"@types/knex@^0.0.65":
+  version "0.0.65"
+  resolved "https://registry.yarnpkg.com/@types/knex/-/knex-0.0.65.tgz#e65a70b5bb617f11e65aac301070ef7f1eeddfd8"
   dependencies:
     "@types/bluebird" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^8.0.33":
+"@types/node@*":
   version "8.0.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.50.tgz#dc545448e128c88c4eec7cd64025fcc3b7604541"
+
+"@types/node@^8.0.53":
+  version "8.0.53"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
 abbrev@1:
   version "1.1.1"
@@ -211,6 +215,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
 async@1.x, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -341,6 +349,21 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@2.3.0, chalk@^2.0.0, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
@@ -358,6 +381,10 @@ chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -490,6 +517,12 @@ debug@^2.2.0:
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -881,6 +914,10 @@ generic-pool@2.4.3:
 generic-pool@^3.1.7:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.2.0.tgz#c1d485ecbd6f18c0513d4741d098a6715eaeeca8"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1789,6 +1826,10 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -2305,7 +2346,7 @@ tslib@^1.7.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
-tslint@^5.7.0:
+tslint@^5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
   dependencies:
@@ -2347,13 +2388,17 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
* Upgraded ts-related deps with `salita --update`
* Explicitly added the new strict parameters to tsconfig
* The only thing that seemed to be broken was Mixin. Updated the index.d.ts and example.ts
* Ran `prettier` over the index.d.ts (it was missing a bunch of semis and indent was incorrect). This is isolated in a commit.

@kblomster if you have time, can you take a look?