### PR TITLE
typo fixed

### DIFF
--- a/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
+++ b/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
@@ -134,10 +134,10 @@ function convertFunction(func, knex) {
 
 function convertQueryBuilderFunction(knexQueryBuilder, func, knex) {
   const QueryBuilderBase = getQueryBuilderBase();
-  const convertpedQueryBuilder = new QueryBuilderBase(knex);
+  const convertedQueryBuilder = new QueryBuilderBase(knex);
 
-  func.call(convertpedQueryBuilder, convertpedQueryBuilder);
-  convertpedQueryBuilder.buildInto(knexQueryBuilder);
+  func.call(convertedQueryBuilder, convertedQueryBuilder);
+  convertedQueryBuilder.buildInto(knexQueryBuilder);
 }
 
 function convertJoinBuilderFunction(knexJoinBuilder, func, knex) {


### PR DESCRIPTION
`convertped` --> `converted`