### PR TITLE
Always omit relations in $toDatabaseJson()

### DIFF
--- a/lib/model/modelToJson.js
+++ b/lib/model/modelToJson.js
@@ -15,12 +15,8 @@ function toJson(model, shallow) {
 function toDatabaseJson(model) {
   const ModelClass = model.constructor;
   const jsonSchema = ModelClass.getJsonSchema();
-
-  if (jsonSchema && ModelClass.pickJsonSchemaProperties) {
-    return modelToJson(model, true, null, jsonSchema.properties);
-  } else {
-    return modelToJson(model, true, ModelClass.getRelations(), null);
-  }
+  const pick = jsonSchema && ModelClass.pickJsonSchemaProperties && jsonSchema.properties;
+  return modelToJson(model, true, ModelClass.getRelations(), pick);
 }
 
 function modelToJson(model, createDbJson, omit, pick) {

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -1130,6 +1130,42 @@ describe('Model', () => {
     expect(json.prop4).to.eql({also: 'this'});
   });
 
+  it('if pickJsonSchemaProperties = true and jsonSchema is given, should omit relations even if defined in jsonSchema', () => {
+    let Model = modelClass('Model');
+
+    Model.pickJsonSchemaProperties = true;
+
+    Model.relationMappings = {
+      someRelation: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Model,
+        join: {
+          from: 'Model.id',
+          to: 'Model.model1Id'
+        }
+      }
+    };
+
+    Model.jsonSchema = {
+      type: 'object',
+      properties: {
+        someRelation: {type: 'object'}
+      }
+    };
+
+    let model = Model.fromJson({
+      someRelation: {
+        value: 'should be removed'
+      }
+    });
+
+    let json = model.$toDatabaseJson();
+    expect(json.someRelation).to.equal(undefined);
+    expect(model.someRelation).to.eql({value: 'should be removed'});
+    json = model.$toJson();
+    expect(json.someRelation).to.eql({value: 'should be removed'});
+  });
+
   it('if pickJsonSchemaProperties = false, should select all properties even if jsonSchema is defined', () => {
     // pickJsonSchemaProperties = false is the default.
     let Model = modelClass('Model');


### PR DESCRIPTION
Even if they are defined in `jsonSchema` and `Model.pickJsonSchemaProperties` is used
For more details, see discussion:
https://gitter.im/Vincit/objection.js?at=5a1331e6f257ad9109bbb035

- [x] PR includes unit test