### PR TITLE
Ran `yarn prettier`

### DIFF
--- a/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
+++ b/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
@@ -40,9 +40,7 @@ function shouldBeAdded(opName, builder, args) {
         return false;
       } else {
         throw new Error(
-          `undefined passed as argument #${i} for '${
-            opName
-          }' operation. Call skipUndefined() method to ignore the undefined values.`
+          `undefined passed as argument #${i} for '${opName}' operation. Call skipUndefined() method to ignore the undefined values.`
         );
       }
     }
@@ -111,9 +109,7 @@ function convertArray(arr, builder, i, opName, skipUndefined) {
     if (item === undefined) {
       if (!skipUndefined) {
         throw new Error(
-          `undefined passed as an item in argument #${i} for '${
-            opName
-          }' operation. Call skipUndefined() method to ignore the undefined values.`
+          `undefined passed as an item in argument #${i} for '${opName}' operation. Call skipUndefined() method to ignore the undefined values.`
         );
       }
     } else if (hasToKnexRawMethod(item)) {
@@ -179,9 +175,7 @@ function convertPlainObject(obj, builder, i, opName, skipUndefined) {
     if (item === undefined) {
       if (!skipUndefined) {
         throw new Error(
-          `undefined passed as a property in argument #${i} for '${
-            opName
-          }' operation. Call skipUndefined() method to ignore the undefined values.`
+          `undefined passed as a property in argument #${i} for '${opName}' operation. Call skipUndefined() method to ignore the undefined values.`
         );
       }
     } else if (hasToKnexRawMethod(item)) {

--- a/lib/queryBuilder/operations/eager/RelationJoinBuilder.js
+++ b/lib/queryBuilder/operations/eager/RelationJoinBuilder.js
@@ -365,9 +365,7 @@ class RelationJoinBuilder {
 
           if (alias.length > ID_LENGTH_LIMIT) {
             throw modelClass.createValidationError({
-              eager: `identifier ${alias} is over ${
-                ID_LENGTH_LIMIT
-              } characters long and would be truncated by the database engine.`
+              eager: `identifier ${alias} is over ${ID_LENGTH_LIMIT} characters long and would be truncated by the database engine.`
             });
           }
 
@@ -395,9 +393,7 @@ class RelationJoinBuilder {
 
             if (alias.length > ID_LENGTH_LIMIT) {
               throw modelClass.createValidationError({
-                eager: `identifier ${alias} is over ${
-                  ID_LENGTH_LIMIT
-                } characters long and would be truncated by the database engine.`
+                eager: `identifier ${alias} is over ${ID_LENGTH_LIMIT} characters long and would be truncated by the database engine.`
               });
             }
 

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -352,9 +352,7 @@ function createRelationProperty(ctx, refString, propName) {
       );
     } else {
       throw ctx.createError(
-        `${
-          propName
-        } must have format TableName.columnName. For example "SomeTable.id" or in case of composite key ["SomeTable.a", "SomeTable.b"].`
+        `${propName} must have format TableName.columnName. For example "SomeTable.id" or in case of composite key ["SomeTable.a", "SomeTable.b"].`
       );
     }
   }

--- a/lib/relations/manyToMany/ManyToManyRelation.js
+++ b/lib/relations/manyToMany/ManyToManyRelation.js
@@ -371,9 +371,7 @@ function createRelationProperty(ctx, refString, messagePrefix) {
       throw ctx.createError('join.through `from` and `to` must point to the same join table.');
     } else {
       throw ctx.createError(
-        `${
-          messagePrefix
-        } must have format JoinTable.columnName. For example "JoinTable.someId" or in case of composite key ["JoinTable.a", "JoinTable.b"].`
+        `${messagePrefix} must have format JoinTable.columnName. For example "JoinTable.someId" or in case of composite key ["JoinTable.a", "JoinTable.b"].`
       );
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "objection",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -81,20 +81,27 @@
       "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
       "dev": true
     },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
     "@types/knex": {
-      "version": "0.0.61",
-      "resolved": "https://registry.npmjs.org/@types/knex/-/knex-0.0.61.tgz",
-      "integrity": "sha512-bPNz/ZJexO9hS/iMx1+iPv2H8k8b42o5KlC0Gib99Ez+0n8oYI1GV7wTbY8eG1RyVFke/2ozLNlC4fySkLcQVQ==",
+      "version": "0.0.67",
+      "resolved": "https://registry.npmjs.org/@types/knex/-/knex-0.0.67.tgz",
+      "integrity": "sha512-zb+GTevX58CmdkZBAatPmE+es176NYvhU2wO3/U7OI+FXsksywnY7lOTfn3vMEr3SLjfxi9jj0W3DEN83sGPfA==",
       "dev": true,
       "requires": {
         "@types/bluebird": "3.5.18",
-        "@types/node": "8.0.50"
+        "@types/events": "1.1.0",
+        "@types/node": "8.0.57"
       }
     },
     "@types/node": {
-      "version": "8.0.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.50.tgz",
-      "integrity": "sha512-N9OVsMBspboNvYaLAQnLEhb2eQ96lavogMR5LoH5k8nb1PvBZHSBFhzhsq2LNzGTBBOtBviOc1GiSu+wlM/pGw==",
+      "version": "8.0.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
+      "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q==",
       "dev": true
     },
     "abbrev": {
@@ -2650,9 +2657,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.1.tgz",
-      "integrity": "sha512-YD5mApxnu/o/u7kiy5C4ouMfzJMXGEQdHyGHtQd0KwN/CrwTwD8RuTNzpInZEYZn9S8m10zDvVT5gAO4pp+0FA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.1.tgz",
+      "integrity": "sha512-oYpQsZk7/0o8+YJUB0LfjkTYQa79gUIF2ESeqvG23IzcgqqvmeOE4+lMG7E/UKX3q3RIj8JHSfhrXWhon1L+zA==",
       "dev": true
     },
     "process-nextick-args": {
@@ -4301,9 +4308,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "coveralls": "cat ./testCoverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "perf": "mocha --slow 60000 --timeout 60000 --reporter spec --recursive perf",
     "perf-opt": "mocha --slow 60000 --timeout 60000 --reporter spec --recursive perf --trace_opt --trace_deopt --trace_inlining",
-    "prettier": "prettier --write 'examples/**/*.js' 'lib/**/*.js' 'tests/**/*.js'",
-    "eslint": "eslint --format codeframe 'examples/**/*.js' 'lib/**/*.js' 'tests/**/*.js'"
+    "prettier": "prettier --write \"examples/**/*.js\" \"lib/**/*.js\" \"tests/**/*.js\"",
+    "eslint": "eslint --format codeframe \"examples/**/*.js\" \"lib/**/*.js\" \"tests/**/*.js\""
   },
   "publishConfig": {
     "tag": "next"
@@ -76,7 +76,7 @@
     "mocha": "^3.4.1",
     "mysql": "^2.13.0",
     "pg": "^6.2.2",
-    "prettier": "^1.7.4",
+    "prettier": "^1.9.1",
     "sqlite3": "3.1.8",
     "tslint": "^5.8.0",
     "typescript": "^2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,9 +1921,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.4:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.1.tgz#91064d778c08c85ac1cbe6b23195c34310d039f9"
+prettier@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"


### PR DESCRIPTION
This should fix the eslint errors I encountered with https://travis-ci.org/Vincit/objection.js/jobs/314914804

Note that the script target doesn't work on windows--I got 

```
$ yarn prettier
yarn run v1.3.2
$ prettier --write 'examples/**/*.js' 'lib/**/*.js' 'tests/**/*.js'
[error] No matching files. Patterns tried: 'examples/**/*.js' 'lib/**/*.js' 'tests/**/*.js' !**/node_modules/** !./node_modules/**
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Replacing the single quotes with escaped double quotes works for both windows and linux. @koskimas, holler if you want that as another PR.