### PR TITLE
Model class thunks

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -4907,7 +4907,7 @@ class Person extends Model {
   static relationMappings = {
     pets: {
       relation: Model.HasManyRelation,
-      modelClass: Animal,
+      modelClass: () => Animal,
       join: {
         from: 'Person.id',
         // Any of the `to` and `from` fields can also be
@@ -4921,7 +4921,7 @@ class Person extends Model {
 
     father: {
       relation: Model.BelongsToOneRelation,
-      modelClass: Person,
+      modelClass: () => Person,
       join: {
         from: 'Person.fatherId',
         to: 'Person.id'
@@ -4930,7 +4930,7 @@ class Person extends Model {
 
     movies: {
       relation: Model.ManyToManyRelation,
-      modelClass: Movie,
+      modelClass: () => Movie,
       join: {
         from: 'Person.id',
         through: {
@@ -4968,10 +4968,16 @@ case of ManyToManyRelation also the join table needs to be defined. This is done
 The `modelClass` passed to the relation mappings is the class of the related model. It can be one of the following:
 
 1. A model class constructor
-2. An absolute path to a module that exports a model class
-3. A path relative to one of the paths in [`modelPaths`](#modelpaths) array.
+1. A thunk (a function with no arguments) that returns a model class constructor
+1. An absolute path to a module that exports a model class
+1. A path relative to one of the paths in [`modelPaths`](#modelpaths) array.
 
-The file path versions are handy for avoiding require loops.
+The thunk and file path versions avoid require loops.
+
+Thunks are recommended if you are packing up your server-side code, as the
+model files won't be `require`able at runtime unless you add `exclude`
+patterns (and even then, it's not as efficient as simply providing the class
+reference).
 
 See [`RelationMapping`](#relationmapping)
 

--- a/examples/express-ts/package.json
+++ b/examples/express-ts/package.json
@@ -21,7 +21,7 @@
     "knex": "^0.14.2",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.2",
+    "objection": "../..",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {

--- a/examples/express-ts/src/models/Animal.ts
+++ b/examples/express-ts/src/models/Animal.ts
@@ -1,6 +1,5 @@
 import { Model } from 'objection';
 import Person from './Person';
-import { join } from 'path';
 
 export default class Animal extends Model {
   readonly id: number;
@@ -33,7 +32,7 @@ export default class Animal extends Model {
       // The related model. This can be either a Model subclass constructor or an
       // absolute file path to a module that exports one. We use the file path version
       // here to prevent require loops.
-      modelClass: join(__dirname, 'Person'),
+      modelClass: () => Person,
       join: {
         from: 'Animal.ownerId',
         to: 'Person.id'

--- a/examples/express-ts/src/models/Movie.ts
+++ b/examples/express-ts/src/models/Movie.ts
@@ -1,6 +1,5 @@
 import { Model } from 'objection';
 import Person from './Person';
-import { join } from 'path';
 
 export default class Movie extends Model {
   readonly id: number;
@@ -26,10 +25,7 @@ export default class Movie extends Model {
   static relationMappings = {
     actors: {
       relation: Model.ManyToManyRelation,
-      // The related model. This can be either a Model subclass constructor or an
-      // absolute file path to a module that exports one. We use the file path version
-      // here to prevent require loops.
-      modelClass: Person,
+      modelClass: () => Person,
       join: {
         from: 'Movie.id',
         // ManyToMany relation needs the `through` object to describe the join table.

--- a/examples/express-ts/yarn.lock
+++ b/examples/express-ts/yarn.lock
@@ -1179,9 +1179,8 @@ object.pick@^1.2.0:
   dependencies:
     isobject "^3.0.1"
 
-objection@^0.9.2:
+objection@../..:
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/objection/-/objection-0.9.2.tgz#ea2abbccbfc887605dfe48748b31e46cb4b317a0"
   dependencies:
     ajv "^5.1.1"
     bluebird "^3.5.0"

--- a/lib/utils/classUtils.js
+++ b/lib/utils/classUtils.js
@@ -10,7 +10,9 @@ function isSubclassOf(Constructor, SuperConstructor) {
       return true;
     }
 
-    let proto = Constructor.prototype.__proto__;
+    // __proto__ is deprecated (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
+    // .getPrototypeOf is supported by node >= 4 (SEE http://kangax.github.io/compat-table/es5/#test-Object.getPrototypeOf)
+    let proto = Constructor.prototype && Object.getPrototypeOf(Constructor.prototype);
     Constructor = proto && proto.constructor;
   }
 

--- a/lib/utils/resolveModel.js
+++ b/lib/utils/resolveModel.js
@@ -8,7 +8,23 @@ const getModel = once(() => require('../model/Model'));
 function resolveModel(modelRef, modelPaths, errorPrefix) {
   const Model = getModel();
 
-  if (typeof modelRef === 'string') {
+  if (isSubclassOf(modelRef, Model)) {
+    // modelRef is already resolved to a Model subclass:
+    return modelRef;
+  } else if (typeof modelRef === 'function') {
+    // modelRef should be a thunk (or no-argument function) that returns a
+    // Model subclass:
+    try {
+      const fromThunk = modelRef();
+      if (isSubclassOf(fromThunk, Model)) {
+        return fromThunk;
+      }
+    } catch (err) {
+      // modelRef isn't a thunk
+    }
+  } else if (typeof modelRef === 'string') {
+    // modelRef should be a path to a module that will export a Model
+    // subclass:
     const modulePath = modelRef;
     let ModelClass = null;
 
@@ -27,15 +43,10 @@ function resolveModel(modelRef, modelPaths, errorPrefix) {
     }
 
     return ModelClass;
-  } else {
-    if (!isSubclassOf(modelRef, Model)) {
-      throw new Error(
-        `${errorPrefix} is not a subclass of Model or a file path to a module that exports one.`
-      );
-    }
-
-    return modelRef;
   }
+  throw new Error(
+    `${errorPrefix} must be either a subclass of Model, a thunk to a subclass of Model, or a file path to a module that exports one.`
+  );
 }
 
 function requireModel(path, errorPrefix) {

--- a/tests/integration/jsonRelations.js
+++ b/tests/integration/jsonRelations.js
@@ -36,7 +36,7 @@ module.exports = session => {
 
           movies: {
             relation: Model.ManyToManyRelation,
-            modelClass: Movie,
+            modelClass: () => Movie,
             join: {
               from: 'Person.id',
               through: {
@@ -59,7 +59,8 @@ module.exports = session => {
         return {
           peopleWhoseFavoriteIAm: {
             relation: Model.HasManyRelation,
-            modelClass: Person,
+            // thunk-reference to a modelClass:
+            modelClass: () => Person,
             join: {
               from: 'Animal.id',
               to: ref('Person.json:stuff.favoritePetId').castInt()
@@ -68,6 +69,7 @@ module.exports = session => {
 
           favoritePerson: {
             relation: Model.BelongsToOneRelation,
+            // direct reference to a modelClass:
             modelClass: Person,
             join: {
               from: ref('Animal.json:favoritePersonName').castText(),

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -113,7 +113,7 @@ class Movie extends objection.Model {
   static relationMappings = {
     actors: {
       relation: objection.Model.ManyToManyRelation,
-      modelClass: Person,
+      modelClass: () => Person,
       join: {
         from: ['Movie.id1', 'Model.id2'],
         through: {

--- a/tests/unit/relations/ManyToManyRelation.js
+++ b/tests/unit/relations/ManyToManyRelation.js
@@ -231,7 +231,7 @@ describe('ManyToManyRelation', () => {
       });
     }).to.throwException(err => {
       expect(err.message).to.equal(
-        'OwnerModel.relationMappings.testRelation: join.through.modelClass is not a subclass of Model or a file path to a module that exports one.'
+        'OwnerModel.relationMappings.testRelation: join.through.modelClass must be either a subclass of Model, a thunk to a subclass of Model, or a file path to a module that exports one.'
       );
     });
   });

--- a/tests/unit/relations/Relation.js
+++ b/tests/unit/relations/Relation.js
@@ -513,6 +513,6 @@ describe('Relation', () => {
     expect(relation.ownerProp.cols).to.eql(['id']);
     expect(relation.ownerProp.props).to.eql(['id']);
     expect(relation.relatedProp.cols).to.eql(['owner_id']);
-    expect(relation.relatedProp.props).to.eql(['ownerId']);
+    expect(relation.relatedProp.props).to.eql(['owner_id']);
   });
 });

--- a/tests/unit/relations/Relation.js
+++ b/tests/unit/relations/Relation.js
@@ -22,8 +22,17 @@ describe('Relation', () => {
     RelatedModelNamedExport = require(__dirname + '/files/RelatedModelNamedExport').RelatedModel;
   });
 
+  function assertValidRelations(relation) {
+    expect(relation.ownerModelClass).to.equal(OwnerModel);
+    expect(relation.relatedModelClass).to.equal(RelatedModel);
+    expect(relation.ownerProp.cols).to.eql(['id']);
+    expect(relation.ownerProp.props).to.eql(['id']);
+    expect(relation.relatedProp.cols).to.eql(['ownerId']);
+    expect(relation.relatedProp.props).to.eql(['ownerId']);
+  }
+
   it('should accept a Model subclass as modelClass', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -34,12 +43,22 @@ describe('Relation', () => {
       }
     });
 
-    expect(relation.ownerModelClass).to.equal(OwnerModel);
-    expect(relation.relatedModelClass).to.equal(RelatedModel);
-    expect(relation.ownerProp.cols).to.eql(['id']);
-    expect(relation.ownerProp.props).to.eql(['id']);
-    expect(relation.relatedProp.cols).to.eql(['ownerId']);
-    expect(relation.relatedProp.props).to.eql(['ownerId']);
+    assertValidRelations(relation);
+  });
+
+  it('should accept a Model subclass thunk as modelClass', () => {
+    let relation = new Relation('testRelation', OwnerModel);
+
+    relation.setMapping({
+      relation: Relation,
+      modelClass: () => require(__dirname + '/files/RelatedModel'),
+      join: {
+        from: 'OwnerModel.id',
+        to: 'RelatedModel.ownerId'
+      }
+    });
+
+    assertValidRelations(relation);
   });
 
   it('should accept a path to a Model subclass as modelClass', () => {
@@ -108,7 +127,7 @@ describe('Relation', () => {
 
     relation.setMapping({
       relation: Relation,
-      modelClass: RelatedModel,
+      modelClass: () => RelatedModel,
       join: {
         from: ['OwnerModel.name', 'OwnerModel.dateOfBirth'],
         to: ['RelatedModel.ownerName', 'RelatedModel.ownerDateOfBirth']
@@ -137,7 +156,7 @@ describe('Relation', () => {
       });
     }).to.throwException(err => {
       expect(err.message).to.equal(
-        'OwnerModel.relationMappings.testRelation: modelClass is not a subclass of Model or a file path to a module that exports one.'
+        'OwnerModel.relationMappings.testRelation: modelClass must be either a subclass of Model, a thunk to a subclass of Model, or a file path to a module that exports one.'
       );
     });
   });
@@ -156,7 +175,7 @@ describe('Relation', () => {
       });
     }).to.throwException(err => {
       expect(err.message).to.match(
-        /OwnerModel\.relationMappings\.testRelation: modelClass path .*\/tests\/unit\/relations\/files\/InvalidModelManyNamedModels exports multiple models\. Don't know which one to choose\./
+        /OwnerModel\.relationMappings\.testRelation: modelClass path .+[\\\/]tests[\\\/]unit[\\\/]relations\/files\/InvalidModelManyNamedModels exports multiple models\. Don't know which one to choose\./
       );
     });
   });
@@ -494,6 +513,6 @@ describe('Relation', () => {
     expect(relation.ownerProp.cols).to.eql(['id']);
     expect(relation.ownerProp.props).to.eql(['id']);
     expect(relation.relatedProp.cols).to.eql(['owner_id']);
-    expect(relation.relatedProp.props).to.eql(['owner_id']);
+    expect(relation.relatedProp.props).to.eql(['ownerId']);
   });
 });

--- a/tests/unit/relations/Relation.js
+++ b/tests/unit/relations/Relation.js
@@ -47,7 +47,7 @@ describe('Relation', () => {
   });
 
   it('should accept a Model subclass thunk as modelClass', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -62,7 +62,7 @@ describe('Relation', () => {
   });
 
   it('should accept a path to a Model subclass as modelClass', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -83,7 +83,7 @@ describe('Relation', () => {
 
   it('should accept a relative path to a Model subclass as modelClass (resolved using Model.modelPaths)', () => {
     OwnerModel.modelPaths = [__dirname + '/files/'];
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -103,7 +103,7 @@ describe('Relation', () => {
   });
 
   it('should accept a module with named exports', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -123,7 +123,7 @@ describe('Relation', () => {
   });
 
   it('should accept a composite key as an array of columns', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -143,7 +143,7 @@ describe('Relation', () => {
   });
 
   it('should fail if modelClass is not a subclass of Model', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -162,7 +162,7 @@ describe('Relation', () => {
   });
 
   it('should fail if modelClass resolves to a module that exports multiple model classes', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -181,7 +181,7 @@ describe('Relation', () => {
   });
 
   it('should fail if modelClass is missing', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -200,7 +200,7 @@ describe('Relation', () => {
   });
 
   it('should fail if modelClass is an invalid file path', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -219,7 +219,7 @@ describe('Relation', () => {
   });
 
   it('should fail if modelClass is a file path that points to a non-model', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -240,7 +240,7 @@ describe('Relation', () => {
   });
 
   it('should fail if relation is not defined', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -258,7 +258,7 @@ describe('Relation', () => {
   });
 
   it('should fail if relation is not a Relation subclass', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -277,7 +277,7 @@ describe('Relation', () => {
   });
 
   it('should fail if OwnerModelClass is not a subclass of Model', () => {
-    let relation = new Relation('testRelation', {});
+    const relation = new Relation('testRelation', {});
 
     expect(() => {
       relation.setMapping({
@@ -294,7 +294,7 @@ describe('Relation', () => {
   });
 
   it('join.to should have format ModelName.columnName', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -313,7 +313,7 @@ describe('Relation', () => {
   });
 
   it('join.to should point to either of the related model classes', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -332,7 +332,7 @@ describe('Relation', () => {
   });
 
   it('join.from should have format ModelName.columnName', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -351,7 +351,7 @@ describe('Relation', () => {
   });
 
   it('join.from should point to either of the related model classes', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -370,7 +370,7 @@ describe('Relation', () => {
   });
 
   it('should fail if join object is missing', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -385,7 +385,7 @@ describe('Relation', () => {
   });
 
   it('should fail if join.from is missing', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -403,7 +403,7 @@ describe('Relation', () => {
   });
 
   it('should fail if join.to is missing', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     expect(() => {
       relation.setMapping({
@@ -421,7 +421,7 @@ describe('Relation', () => {
   });
 
   it('the values of `join.to` and `join.from` can be swapped', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     relation.setMapping({
       relation: Relation,
@@ -441,7 +441,7 @@ describe('Relation', () => {
   });
 
   it('relatedCol and ownerCol should be in database format', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     Object.defineProperty(OwnerModel, 'tableName', {
       get() {
@@ -485,7 +485,7 @@ describe('Relation', () => {
   });
 
   it('should allow relations on tables under a schema', () => {
-    let relation = new Relation('testRelation', OwnerModel);
+    const relation = new Relation('testRelation', OwnerModel);
 
     Object.defineProperty(OwnerModel, 'tableName', {
       get() {

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -125,7 +125,7 @@ declare namespace Objection {
 
   export interface RelationMapping {
     relation: Relation;
-    modelClass: ModelClass<any> | string;
+    modelClass: ModelClass<any> | string | (() => ModelClass<any>);
     join: RelationJoin;
     modify?: <T>(queryBuilder: QueryBuilder<T>) => QueryBuilder<T>;
     filter?: <T>(queryBuilder: QueryBuilder<T>) => QueryBuilder<T>;


### PR DESCRIPTION
I'm webpacking my server-side code (to both reduce the number of files I'm installing and to support uglification), and path references to model classes don't work in that environment.

I can't give a direct reference to my Model subclasses in my `relationMappings` because that causes circular dependencies.

I'm adding thunk-dereferenced Model subclasses in this PR, so Objection doesn't have to do `require`s in a environment where webpack has concatenated all the files, or requiring all the model class modules to be explicitly `exclude`d from webpack (and then hope to figure out path resolution in different environments.