### PR TITLE
Add simple string matching to forEachOperation()

### DIFF
--- a/lib/queryBuilder/QueryBuilderOperationSupport.js
+++ b/lib/queryBuilder/QueryBuilderOperationSupport.js
@@ -152,10 +152,23 @@ class QueryBuilderOperationSupport {
   forEachOperation(operationSelector, callback, match) {
     match = match == null ? true : match;
 
+    let check;
     if (operationSelector instanceof RegExp) {
-      forEachOperationRegex(this._operations, operationSelector, callback, match);
+      check = op => operationSelector.test(op.name);
+    } else if (typeof operationSelector === 'string') {
+      check = op => op.name === operationSelector;
     } else {
-      forEachOperationInstanceOf(this._operations, operationSelector, callback, match);
+      check = op => op.is(operationSelector);
+    }
+
+    for (let i = 0, l = this._operations.length; i < l; ++i) {
+      const op = this._operations[i];
+
+      if (check(op) === match) {
+        if (callback(op, i) === false) {
+          break;
+        }
+      }
     }
 
     return this;
@@ -259,30 +272,6 @@ class QueryBuilderOperationSupport {
   skipUndefined() {
     this._context.options.skipUndefined = true;
     return this;
-  }
-}
-
-function forEachOperationRegex(operations, operationSelector, callback, match) {
-  for (let i = 0, l = operations.length; i < l; ++i) {
-    const op = operations[i];
-
-    if (operationSelector.test(op.name) === match) {
-      if (callback(op, i) === false) {
-        break;
-      }
-    }
-  }
-}
-
-function forEachOperationInstanceOf(operations, operationSelector, callback, match) {
-  for (let i = 0, l = operations.length; i < l; ++i) {
-    const op = operations[i];
-
-    if (op.is(operationSelector) === match) {
-      if (callback(op, i) === false) {
-        break;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
I thought it would be nice to be able to use `builder.findLastOperation('range')`.

This simple change adds that, and makes the current code a bit more compact also.