### PR TITLE
Add property data paths to nested insert and upsert validations

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -70,7 +70,7 @@ class AjvValidator extends Validator {
     }
 
     if (validator.errors) {
-      throw parseValidationError(validator.errors, model.constructor);
+      throw parseValidationError(validator.errors, model.constructor, options);
     }
 
     return json;
@@ -152,20 +152,20 @@ class AjvValidator extends Validator {
   }
 }
 
-function parseValidationError(errors, modelClass) {
+function parseValidationError(errors, modelClass, options) {
   const errorHash = {};
-  let index = 0;
 
   for (let i = 0; i < errors.length; ++i) {
-    let error = errors[i];
+    const error = errors[i];
     let key = error.dataPath.substring(1);
 
-    if (!key) {
-      const params = error.params;
-      key = params && (params.missingProperty || params.additionalProperty);
-      if (!key) {
-        key = (index++).toString();
-      }
+    const params = error.params;
+    if (!key && params) {
+      key = params.missingProperty || params.additionalProperty;
+    }
+
+    if (options.dataPath) {
+      key = [...options.dataPath, key].join('.');
     }
 
     // More than one error can occur for the same key in Ajv, merge them in the array:
@@ -175,7 +175,7 @@ function parseValidationError(errors, modelClass) {
     array.unshift({
       message: error.message,
       keyword: error.keyword,
-      params: error.params
+      params
     });
   }
 

--- a/lib/queryBuilder/graphInserter/DependencyGraph.js
+++ b/lib/queryBuilder/graphInserter/DependencyGraph.js
@@ -28,10 +28,10 @@ class DependencyGraph {
 
     if (Array.isArray(models)) {
       for (let i = 0, l = models.length; i < l; ++i) {
-        this.buildForModel(modelClass, models[i], null, null, this.allowedRelations);
+        this.buildForModel(modelClass, models[i], null, null, this.allowedRelations, []);
       }
     } else {
-      this.buildForModel(modelClass, models, null, null, this.allowedRelations);
+      this.buildForModel(modelClass, models, null, null, this.allowedRelations, []);
     }
 
     this.solveReferences();
@@ -47,7 +47,7 @@ class DependencyGraph {
     return this.nodes;
   }
 
-  buildForModel(modelClass, model, parentNode, rel, allowedRelations) {
+  buildForModel(modelClass, model, parentNode, rel, allowedRelations, dataPath) {
     if (!model || !model.$isObjectionModel) {
       throw modelClass.createValidationError({
         type: ValidationErrorType.InvalidGraph,
@@ -59,7 +59,7 @@ class DependencyGraph {
       model[modelClass.uidProp] = this.createUid();
     }
 
-    const node = new DependencyNode(parentNode, model, modelClass, rel);
+    const node = new DependencyNode(parentNode, model, modelClass, rel, dataPath);
     const isRelate = this.isRelate(modelClass, model, parentNode, rel);
     const dbRef = model[modelClass.dbRefProp];
 
@@ -106,36 +106,39 @@ class DependencyGraph {
       node.markAsInserted();
     }
 
-    this.buildForRelations(modelClass, node, allowedRelations);
+    this.buildForRelations(modelClass, node, allowedRelations, dataPath);
   }
 
-  buildForRelations(modelClass, node, allowedRelations) {
+  buildForRelations(modelClass, node, allowedRelations, dataPath) {
     const model = node.model;
     const relations = modelClass.getRelationArray();
 
     for (let i = 0, l = relations.length; i < l; ++i) {
       const rel = relations[i];
-      const relModels = model[rel.name];
+      const relData = model[rel.name];
 
       let nextAllowed = null;
+      if (relData) {
+        if (allowedRelations instanceof RelationExpression) {
+          nextAllowed = allowedRelations.childExpression(rel.name);
 
-      if (relModels && allowedRelations instanceof RelationExpression) {
-        nextAllowed = allowedRelations.childExpression(rel.name);
-
-        if (!nextAllowed) {
-          throw modelClass.createValidationError({
-            type: ValidationErrorType.UnallowedRelation,
-            message: 'trying to insert an unallowed relation'
-          });
+          if (!nextAllowed) {
+            throw modelClass.createValidationError({
+              type: ValidationErrorType.UnallowedRelation,
+              message: 'trying to insert an unallowed relation'
+            });
+          }
         }
-      }
 
-      if (Array.isArray(relModels)) {
-        for (let i = 0, l = relModels.length; i < l; ++i) {
-          this.buildForModel(rel.relatedModelClass, relModels[i], node, rel, nextAllowed);
+        const relPath = [...dataPath, rel.name];
+        const relModelClass = rel.relatedModelClass;
+        if (Array.isArray(relData)) {
+          for (let i = 0, l = relData.length; i < l; ++i) {
+            this.buildForModel(relModelClass, relData[i], node, rel, nextAllowed, [...relPath, i]);
+          }
+        } else {
+          this.buildForModel(relModelClass, relData, node, rel, nextAllowed, relPath);
         }
-      } else if (relModels) {
-        this.buildForModel(rel.relatedModelClass, relModels, node, rel, nextAllowed);
       }
     }
   }

--- a/lib/queryBuilder/graphInserter/DependencyNode.js
+++ b/lib/queryBuilder/graphInserter/DependencyNode.js
@@ -1,10 +1,11 @@
 class DependencyNode {
-  constructor(parentNode, model, modelClass, relation) {
+  constructor(parentNode, model, modelClass, relation, dataPath) {
     this.id = model[modelClass.uidProp];
     this.parentNode = parentNode || null;
     this.model = model;
     this.modelClass = modelClass;
     this.relation = relation || null;
+    this.dataPath = dataPath;
     this.needs = [];
     this.isNeededBy = [];
     this.manyToManyConnections = [];

--- a/lib/queryBuilder/graphInserter/inserter.js
+++ b/lib/queryBuilder/graphInserter/inserter.js
@@ -16,12 +16,15 @@ module.exports = builder => {
 
     let insertQuery = tableInsertion.modelClass.query().childQueryOf(builder);
 
-    for (let i = 0, l = tableInsertion.items.length; i < l; ++i) {
-      const { model, relation } = tableInsertion.items[i];
-
+    const items = tableInsertion.items;
+    for (let i = 0, l = items.length; i < l; ++i) {
+      const item = items[i];
+      const { model, relation } = item;
       // We need to validate here since at this point the models should no longer contain any special properties.
-      const json = model.$validate();
-
+      const dataPath = item.node.dataPath;
+      const json = model.$validate(model, {
+        dataPath: dataPath.length ? dataPath : null
+      });
       // Set the return value back to model in case defaults were set.
       model.$set(json);
 

--- a/lib/queryBuilder/graphUpserter/UpsertGraph.js
+++ b/lib/queryBuilder/graphUpserter/UpsertGraph.js
@@ -13,8 +13,9 @@ const { Type: ValidationErrorType } = require('../../model/ValidationError');
 // the needed actions by fetching the current state of the graph from the
 // database. Only ids and foreign keys needed by the relations are fetched.
 class UpsertGraph {
-  constructor(upsert, opt) {
-    this.upsert = asArray(upsert);
+  constructor(upsert, isArray, opt) {
+    this.upsert = upsert;
+    this.isArray = isArray;
     this.rootModelClass = this.upsert[0].constructor;
     this.relExpr = RelationExpression.fromGraph(upsert);
     this.nodes = [];
@@ -73,48 +74,60 @@ class UpsertGraph {
   }
 
   buildGraph(current) {
-    this.doBuildGraph(this.rootModelClass, this.upsert, current, null, this.relExpr);
+    this.doBuildGraph(
+      this.rootModelClass,
+      this.upsert,
+      current,
+      this.isArray,
+      null,
+      this.relExpr,
+      []
+    );
   }
 
-  doBuildGraph(modelClass, upsert, current, parentNode, relExpr) {
+  doBuildGraph(modelClass, upsert, current, isArray, parentNode, relExpr, dataPath) {
     this.buildGraphArray(
       modelClass,
       ensureArray(upsert),
       ensureArray(current),
+      isArray,
       parentNode,
-      relExpr
+      relExpr,
+      dataPath
     );
   }
 
-  buildGraphArray(modelClass, upsert, current, parentNode, relExpr) {
+  buildGraphArray(modelClass, upsert, current, isArray, parentNode, relExpr, dataPath) {
     const idProp = modelClass.getIdPropertyArray();
 
     const upsertById = keyBy(upsert, model => model.$propKey(idProp));
     const currentById = keyBy(current, model => model.$propKey(idProp));
 
-    upsert.forEach(upsert => {
+    upsert.forEach((upsert, index) => {
       const key = upsert.$propKey(idProp);
       const current = currentById[key];
-
-      this.buildGraphSingle(modelClass, upsert, current, parentNode, relExpr);
+      const path = isArray ? [...dataPath, index] : dataPath;
+      this.buildGraphSingle(modelClass, upsert, current, parentNode, relExpr, path);
     });
 
     current.forEach(current => {
       const key = current.$propKey(idProp);
       const upsert = upsertById[key];
-
       if (!upsert) {
-        this.buildGraphSingle(modelClass, upsert, current, parentNode, relExpr);
+        // These nodes result in delete and unrelate operations and nothing gets validated.
+        // Use an index of -1  for dataPath here, as it should never actually get used.
+        const path = isArray ? [...dataPath, -1] : dataPath;
+        this.buildGraphSingle(modelClass, upsert, current, parentNode, relExpr, path);
       }
     });
   }
 
-  buildGraphSingle(modelClass, upsert, current, parentNode, relExpr) {
+  buildGraphSingle(modelClass, upsert, current, parentNode, relExpr, dataPath) {
     if (!upsert && !current) {
       return;
     }
 
-    const node = new UpsertNode(parentNode, relExpr, upsert, current, this.opt);
+    const node = new UpsertNode(parentNode, relExpr, upsert, current, dataPath, this.opt);
     this.nodes.push(node);
 
     if (upsert) {
@@ -122,8 +135,9 @@ class UpsertGraph {
     }
 
     if (parentNode) {
-      parentNode.relations[relExpr.name] = parentNode.relations[relExpr.name] || [];
-      parentNode.relations[relExpr.name].push(node);
+      const relations = parentNode.relations;
+      const relation = (relations[relExpr.name] = relations[relExpr.name] || []);
+      relation.push(node);
     }
 
     // No need to build the graph down from a deleted node.
@@ -132,10 +146,19 @@ class UpsertGraph {
     }
 
     relExpr.forEachChildExpression(modelClass.getRelations(), (expr, relation) => {
-      const relUpsert = upsert && upsert[relation.name];
-      const relCurrent = current && current[relation.name];
+      const name = relation.name;
+      const relUpsert = upsert && upsert[name];
+      const relCurrent = current && current[name];
 
-      this.doBuildGraph(relation.relatedModelClass, relUpsert, relCurrent, node, expr);
+      this.doBuildGraph(
+        relation.relatedModelClass,
+        relUpsert,
+        relCurrent,
+        Array.isArray(relUpsert),
+        node,
+        expr,
+        [...dataPath, name]
+      );
     });
   }
 }

--- a/lib/queryBuilder/graphUpserter/UpsertNode.js
+++ b/lib/queryBuilder/graphUpserter/UpsertNode.js
@@ -19,13 +19,14 @@ const ChangeType = {
 };
 
 class UpsertNode {
-  constructor(parentNode, relExpr, upsertModel, currentModel, opt) {
+  constructor(parentNode, relExpr, upsertModel, currentModel, dataPath, opt) {
     this.parentNode = parentNode || null;
     this.relExpr = relExpr;
     this.relPathFromRoot = getRelationPathFromRoot(this);
     this.upsertModel = upsertModel || null;
     this.currentModel = currentModel || null;
     this.relations = Object.create(null);
+    this.dataPath = dataPath;
     this.opt = opt || {};
 
     const { types, omitFromUpdate } = getTypes(this);
@@ -242,17 +243,16 @@ function decideType(node, defaultType, option, optionType = UpsertNodeType.None)
 }
 
 function getRelationPathFromRoot(node) {
-  let path = '';
+  const path = [];
 
   while (node) {
     if (node.relExpr.name) {
-      path = node.relExpr.name + (path ? '.' : '') + path;
+      path.unshift(node.relExpr.name);
     }
-
     node = node.parentNode;
   }
 
-  return path;
+  return path.join('.');
 }
 
 function hasChanges(currentModel, upsertModel) {

--- a/lib/queryBuilder/operations/UpsertGraphOperation.js
+++ b/lib/queryBuilder/operations/UpsertGraphOperation.js
@@ -19,7 +19,7 @@ class UpsertGraphOperation extends InsertGraphOperation {
   }
 
   onBefore1(builder) {
-    this.graph = new UpsertGraph(this.models, this.upsertOpt);
+    this.graph = new UpsertGraph(this.models, this.isArray, this.upsertOpt);
 
     return this.graph.build(builder).then(() => this.delete(builder));
   }
@@ -152,7 +152,11 @@ class UpsertGraphOperation extends InsertGraphOperation {
 
         // The models were created by the parent class `InsertGraphOperation` with a
         // skipValidation flag. We need to explicitly call $validate here.
-        node.upsertModel.$validate(node.upsertModel, { patch: patch });
+        const dataPath = node.dataPath;
+        node.upsertModel.$validate(node.upsertModel, {
+          patch: patch,
+          dataPath: dataPath.length ? dataPath : null
+        });
 
         if (node.parentNode) {
           // Call patch through parent's $relatedQuery to make things like many-to-many

--- a/tests/integration/upsertGraph.js
+++ b/tests/integration/upsertGraph.js
@@ -1885,14 +1885,22 @@ module.exports = session => {
           ]
         };
 
+        const errorKeys = [
+          'model1Prop1',
+          'model1Relation1.model1Prop1',
+          'model1Relation2.0.model2Relation1.1.model1Prop1'
+        ];
+
         return Promise.map(fails, fail => {
           return transaction(session.knex, trx => Model1.query(trx).upsertGraph(fail)).reflect();
         })
           .then(results => {
             // Check that all transactions have failed because of a validation error.
-            results.forEach(res => {
+            results.forEach((res, index) => {
               expect(res.isRejected()).to.equal(true);
-              expect(res.reason().data.model1Prop1[0].message).to.equal('should be string,null');
+              expect(res.reason().data[errorKeys[index]][0].message).to.equal(
+                'should be string,null'
+              );
             });
 
             return Model1.query(session.knex)
@@ -2031,6 +2039,8 @@ module.exports = session => {
           }
         ];
 
+        const errorKeys = ['model1Prop2', 'model1Relation1.model1Prop2'];
+
         return Promise.map(fails, fail => {
           return transaction(session.knex, trx =>
             Model1.query(trx).upsertGraph(fail, { update: true })
@@ -2038,9 +2048,9 @@ module.exports = session => {
         })
           .then(results => {
             // Check that all transactions have failed because of a validation error.
-            results.forEach(res => {
+            results.forEach((res, index) => {
               expect(res.isRejected()).to.equal(true);
-              expect(res.reason().data.model1Prop2[0].message).to.equal(
+              expect(res.reason().data[errorKeys[index]][0].message).to.equal(
                 "should have required property 'model1Prop2'"
               );
             });


### PR DESCRIPTION
When validation errors happen in graph inserts and upserts of nested relations data, Objection 
currently doesn't specific the location of the error.

This PR calculated dataPaths for graph inserts and upserts, and then provides these as relative JSON pointers instead of plain property names in the validation errors. If the data is only on the root level of the graph, then these two behaviors are actually the same.

As discussed on [Gitter](https://gitter.im/Vincit/objection.js?at=5a48d9f368d092bb620aace4), the convention of how to handle JSON pointers, and wether they should be absolute or relative paths to the data still needs some more thought and a proper decision.

For now, here the current state of things, so the discussion can be continued on in the issue here.