### PR TITLE
Handle undefined returns from $beforeValidate()

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -48,7 +48,10 @@ class AjvValidator extends Validator {
     // rare case that the given model has implemented the hook.
     if (model.$beforeValidate !== model.$objectionModelClass.prototype.$beforeValidate) {
       ctx.jsonSchema = cloneDeep(ctx.jsonSchema);
-      ctx.jsonSchema = model.$beforeValidate(ctx.jsonSchema, json, options);
+      const ret = model.$beforeValidate(ctx.jsonSchema, json, options);
+      if (ret !== undefined) {
+        ctx.jsonSchema = ret;
+      }
     }
   }
 


### PR DESCRIPTION
This simple PR detects the return of `undefined` from `$beforeValidate()` and uses the default `jsonSchema` in this case. The handler can return `null` if it explicitly wants to disable the use of a schema.