### PR TITLE
Make QueryBuilder.traverse() aware of range()

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -585,7 +585,9 @@ class QueryBuilder extends QueryBuilderBase {
     }
 
     return this.runAfter(result => {
-      this.resultModelClass().traverse(modelClass, result, traverser);
+      // Range operations nest the result data inside the result object.
+      const data = this.has(RangeOperation) ? result.result : result;
+      this.resultModelClass().traverse(modelClass, data, traverser);
       return result;
     });
   }


### PR DESCRIPTION
When `range()` is used before `traverse()`, the result is nested inside the result object, and `traverse()` starts traversing the wrong data structure.

This simple PR fixes this case. If this is deemed useful, I will write unit tests for it.