### PR TITLE
Make RunAfterOperation aware of range()

### DIFF
--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -4,6 +4,7 @@ const QueryBuilderOperationSupport = require('./QueryBuilderOperationSupport');
 const isSqlite = require('../utils/knexUtils').isSqlite;
 
 const KnexOperation = require('./operations/KnexOperation');
+const RangeOperation = require('./operations/RangeOperation');
 const SelectOperation = require('./operations/SelectOperation');
 const WhereRefOperation = require('./operations/WhereRefOperation');
 const ReturningOperation = require('./operations/ReturningOperation');

--- a/lib/queryBuilder/QueryBuilderOperationSupport.js
+++ b/lib/queryBuilder/QueryBuilderOperationSupport.js
@@ -118,6 +118,16 @@ class QueryBuilderOperationSupport {
     return this.indexOfOperation(operationSelector) !== -1;
   }
 
+  hasOperationBefore(operation, operationSelector) {
+    // Returns true if `operationSelector` is encountered before the given operation object.
+    const idx1 = this._operations.indexOf(operation);
+    if (idx1 >= 0) {
+      const idx2 = this.indexOfOperation(operationSelector);
+      return idx2 >= 0 && idx2 < idx1;
+    }
+    return false;
+  }
+
   indexOfOperation(operationSelector) {
     let idx = -1;
 

--- a/lib/queryBuilder/operations/RunAfterOperation.js
+++ b/lib/queryBuilder/operations/RunAfterOperation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const QueryBuilderOperation = require('./QueryBuilderOperation');
+const RangeOperation = require('./RangeOperation');
 
 class RunAfterOperation extends QueryBuilderOperation {
   onAdd(builder, args) {
@@ -9,7 +10,14 @@ class RunAfterOperation extends QueryBuilderOperation {
   }
 
   onAfter3(builder, result) {
-    return this.func.call(builder, result, builder);
+    // If there is a RangeOperation before the RunAfterOperation, take the nesting of the
+    // result array inside the result object into account: `{ result: [...], total: ... }`
+    if (result && builder.hasOperationBefore(this, RangeOperation)) {
+      result.result = this.func.call(builder, result.result, builder);
+      return result;
+    } else {
+      return this.func.call(builder, result, builder);
+    }
   }
 }
 


### PR DESCRIPTION
When `range()` is used before a `RunAfterOperation` (e.g. through `traverse()`), the received result is already nested inside the `range()` result object and needs to be unwrapped again for further processing.

This PR makes `RunAfterOperation` aware of the situation where it is preceded by a `RangeOperation`, and knows how to handle the result.

If this is deemed useful, I will write unit tests for it.