### PR TITLE
Implement better error reporting in applyFilter()

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -128,7 +128,11 @@ class QueryBuilder extends QueryBuilderBase {
     const namedFilters = this._modelClass.namedFilters;
 
     for (let i = 0, l = arguments.length; i < l; ++i) {
-      const filter = namedFilters[arguments[i]];
+      const name = arguments[i];
+      const filter = namedFilters[name];
+      if (typeof filter !== 'function') {
+        throw new Error(`Could not find filter "${name}".`);
+      }
       filter(this);
     }
 


### PR DESCRIPTION
Currently, when an unknown filter is passed to `applyFilter()`, I get an unspecific error that is quite misleading:
`TypeError: filter is not a function`   

This PR uses the same format as is already used [elsewhere](https://github.com/Vincit/objection.js/blob/397ad53d55c37c49227dacfe16613b1fd54d7b8f/lib/relations/Relation.js#L341) for inexistent filters, resulting in this error instead:
`Error: Could not find filter "unknownFilter".`