### PR TITLE
Remove the need for getRootModelClass()

### DIFF
--- a/lib/queryBuilder/graphUpserter/UpsertGraph.js
+++ b/lib/queryBuilder/graphUpserter/UpsertGraph.js
@@ -15,7 +15,7 @@ const asArray = require('../../utils/objectUtils').asArray;
 class UpsertGraph {
   constructor(upsert, opt) {
     this.upsert = asArray(upsert);
-    this.rootModelClass = getRootModelClass(upsert);
+    this.rootModelClass = this.upsert[0].constructor;
     this.relExpr = RelationExpression.fromGraph(upsert);
     this.nodes = [];
     // Keys are upsert models and values are corresponding nodes.
@@ -132,14 +132,6 @@ class UpsertGraph {
 
       this.doBuildGraph(relation.relatedModelClass, relUpsert, relCurrent, node, expr);
     });
-  }
-}
-
-function getRootModelClass(graph) {
-  if (Array.isArray(graph)) {
-    return graph[0].constructor;
-  } else {
-    return graph.constructor;
   }
 }
 


### PR DESCRIPTION
This is a small simplification that I noticed while looking through `UpsertGraph`: Due to the use of `asArray()`, we can count on `this.upsert` always being an array, and as a result there isn't really a need for `getRootModelClass()` anymore.