### PR TITLE
Do not patch primary ids in upsertGraph()

### DIFF
--- a/lib/queryBuilder/operations/UpsertGraphOperation.js
+++ b/lib/queryBuilder/operations/UpsertGraphOperation.js
@@ -154,7 +154,10 @@ class UpsertGraphOperation extends InsertGraphOperation {
 
         // The models were created by the parent class `InsertGraphOperation` with a
         // skipValidation flag. We need to explicitly call $validate here.
-        node.upsertModel.$validate(node.upsertModel, {patch: patch});
+        const json = node.upsertModel.$validate(node.upsertModel, {patch: patch});
+        // Remove the id properties from the json. Note that this does not not modify
+        // node.upsertModel, since $validate() returns a clone.
+        json.$omit(node.upsertModel.constructor.getIdPropertyArray());
 
         if (node.parentNode) {
           // Call patch through parent's $relatedQuery to make things like many-to-many
@@ -163,7 +166,7 @@ class UpsertGraphOperation extends InsertGraphOperation {
             .$relatedQuery(node.relationName)
             .childQueryOf(builder, true)
             .findById(node.upsertModel.$id())
-            [patch ? 'patch' : 'update'](node.upsertModel);
+            [patch ? 'patch' : 'update'](json);
         } else {
           query = node.upsertModel
             .$query()


### PR DESCRIPTION
As outlined on [Gitter](https://gitter.im/Vincit/objection.js?at=5a4f937f232e79134dccea2d):

> It looks like the primary id values get reassigned in `upsertGraph()`. I get a lot of statements that looks like this: `update "model_name" set "id" = $1, ... where "model_name"."id" = $X`, with $1 and $X having the same value.

This patch fixes this. It also results in two failing tests, but I have a hunch these may not actually be errors, but a change of behaviour that needs to be tested for differently now.

As always, just a suggestion.
  