### PR TITLE
Switch to Ajv errorDataPath: 'property' configuration

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -7,7 +7,7 @@ class AjvValidator extends Validator {
   constructor(conf) {
     super();
 
-    this.ajvOptions = Object.assign({}, conf.options);
+    this.ajvOptions = Object.assign({ errorDataPath: 'property' }, conf.options);
 
     // Create a normal Ajv instance.
     this.ajv = new Ajv(
@@ -15,14 +15,14 @@ class AjvValidator extends Validator {
         {
           useDefaults: true
         },
-        conf.options
+        this.ajvOptions
       )
     );
 
     // Create an instance that doesn't set default values. We need this one
     // to validate `patch` objects (objects that have a subset of properties).
     this.ajvNoDefaults = new Ajv(
-      Object.assign({}, conf.options, {
+      Object.assign({}, this.ajvOptions, {
         useDefaults: false
       })
     );
@@ -157,17 +157,11 @@ function parseValidationError(errors, modelClass, options) {
 
   for (let i = 0; i < errors.length; ++i) {
     const error = errors[i];
-    let key = error.dataPath.substring(1);
-
-    const params = error.params;
-    if (!key && params) {
-      key = params.missingProperty || params.additionalProperty;
-    }
-
-    if (options.dataPath) {
-      key = `${options.dataPath.substring(1)}.${key}`;
-    }
-
+    const dataPath = `${options.dataPath || ''}${error.dataPath}`;
+    // Unknown properties are reported in `['propertyName']` notation,
+    // so replace those with dot-notation, see:
+    // https://github.com/epoberezkin/ajv/issues/671
+    const key = dataPath.replace(/\['([^' ]*)'\]/g, '.$1').substring(1);
     // More than one error can occur for the same key in Ajv, merge them in the array:
     const array = errorHash[key] || (errorHash[key] = []);
     // Use unshift instead of push so that the last error ends up at [0],
@@ -175,7 +169,7 @@ function parseValidationError(errors, modelClass, options) {
     array.unshift({
       message: error.message,
       keyword: error.keyword,
-      params
+      params: error.params
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "types": "./typings/objection/index.d.ts",
   "dependencies": {
-    "ajv": "^6.0.0",
+    "ajv": "^6.0.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4"
   },

--- a/tests/integration/upsertGraph.js
+++ b/tests/integration/upsertGraph.js
@@ -2051,7 +2051,7 @@ module.exports = session => {
             results.forEach((res, index) => {
               expect(res.isRejected()).to.equal(true);
               expect(res.reason().data[errorKeys[index]][0].message).to.equal(
-                "should have required property 'model1Prop2'"
+                'is a required property'
               );
             });
           })

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -140,7 +140,7 @@ describe('Model', () => {
         Model1.fromJson({ a: 'a', c: { d: 'test', e: [{ additional: true }] } });
       }).to.throwException(exp => {
         expect(exp).to.be.a(ValidationError);
-        expect(exp.data).to.have.property('c.e[0]');
+        expect(exp.data).to.have.property('c.e[0].additional');
       });
     });
 


### PR DESCRIPTION
As mentioned today on [Gitter](https://gitter.im/Vincit/objection.js?at=5a57499ab48e8c3566c8fdd2), this PR switches to using Ajv's `errorDataPath: 'property'` configuration to always receive property data-paths in validation errors, leading to some nice simplifications and more consistent error messages.