### PR TITLE
Fix mergeEager() for child expressions with namedFilters

### DIFF
--- a/lib/queryBuilder/RelationExpression.js
+++ b/lib/queryBuilder/RelationExpression.js
@@ -1,4 +1,5 @@
-const merge = require('lodash/merge');
+const mergeWith = require('lodash/mergeWith');
+const union = require('lodash/union');
 const clone = require('lodash/clone');
 const values = require('lodash/values');
 const cloneDeep = require('lodash/cloneDeep');
@@ -59,9 +60,9 @@ class RelationExpression {
     const merged = this.clone();
     expr = RelationExpression.parse(expr);
 
-    merged.children = merge(merged.children, expr.children);
-    merged.args = merge(merged.args, expr.args);
-    merged.filters = merge(merged.filters, expr.filters);
+    merged.children = mergeWithUnion(merged.children, expr.children);
+    merged.args = mergeWithUnion(merged.args, expr.args);
+    merged.filters = mergeWithUnion(merged.filters, expr.filters);
     merged.numChildren = Object.keys(merged.children).length;
 
     // Handle recursive and all recursive nodes.
@@ -375,6 +376,14 @@ function findNodesAtPath(target, path, results) {
   }
 
   return results;
+}
+
+function mergeWithUnion(obj, src) {
+  return mergeWith(obj, src, (obj, src) => {
+    if (Array.isArray(obj) && Array.isArray(src)) {
+      return union(obj, src);
+    }
+  });
 }
 
 Object.defineProperties(RelationExpression.prototype, {

--- a/tests/unit/queryBuilder/RelationExpression.js
+++ b/tests/unit/queryBuilder/RelationExpression.js
@@ -750,6 +750,8 @@ describe('RelationExpression', () => {
     testMerge('a.^', 'a.^6', 'a.^');
     testMerge('a.^6', 'a.^', 'a.^');
     testMerge('a.a', 'a.^', 'a.^');
+    testMerge('a(f)', 'a(g)', 'a(f, g)');
+    testMerge('a.b(f)', 'a.b(g)', 'a.b(f, g)');
   });
 
   describe('#toString', () => {


### PR DESCRIPTION
As mentioned on [Gitter](https://gitter.im/Vincit/objection.js?at=5a5f9104b48e8c3566f10cf8):

I've developed a habit of defining `namedFilters` recursively throughout graphs. .e.g if I have three nested models that relate to each  other, and they all define a filter named `someFilter`, I use eager statements in each to load just the next level of relations, e.g.:
```js
const namedFilters = {
  someFilter: query => query.mergeEager('relationName(someFilter)')
}.
```

This works well, but as soon as I combine it with another filter that also defines a `mergeEager()` statement with child filters on the same children, the eager statements don't seem to get merged, and only the one that is applied last appears to be used as the eager statement on the child expression. If I flatten the statement and remove the recursive filter calls, then the merging appears to work.

This PR fixes this issue by allowing `mergeEager()` to merge arrays within the children expression by the use of array concatenation, thus correctly merging the `args` properties of the children expressions.