### PR TITLE
Implement new QueryBuilder.has*() and is*() checks

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -2989,10 +2989,10 @@ boolean|false if the query will never be executed.
 
 
 
-#### isFindQuery
+#### isFind
 
 ```js
-const isFindQuery = queryBuilder.isFindQuery();
+const isFind = queryBuilder.isFind();
 ```
 
 Returns true if the query is read-only.
@@ -3002,6 +3002,143 @@ Returns true if the query is read-only.
 Type|Description
 ----|-----------------------------
 boolean|true if the query is read-only.
+
+
+
+
+#### isInsert
+
+```js
+const isInsert = queryBuilder.isInsert();
+```
+
+Returns true if the query performs an insert operation.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query performs an insert operation.
+
+
+
+
+#### isUpdate
+
+```js
+const isUpdate = queryBuilder.isUpdate();
+```
+
+Returns true if the query performs an update operation.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query performs an update operation.
+
+
+
+
+#### isDelete
+
+```js
+const isDelete = queryBuilder.isDelete();
+```
+
+Returns true if the query performs a delete operation.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query performs a delete operation.
+
+
+
+
+#### isRelate
+
+```js
+const isRelate = queryBuilder.isRelate();
+```
+
+Returns true if the query performs a relate operation.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query performs a relate operation.
+
+
+
+
+#### isUnrelate
+
+```js
+const isUnrelate = queryBuilder.isUnrelate();
+```
+
+Returns true if the query performs an unrelate operation.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query performs an unrelate operation.
+
+
+
+
+#### hasWheres
+
+```js
+const hasWheres = queryBuilder.hasWheres();
+```
+
+Returns true if the query contains where statements.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query contains where statements.
+
+
+
+
+#### hasSelects
+
+```js
+const hasSelects = queryBuilder.hasSelects();
+```
+
+Returns true if the query contains any specific select staments, such as:
+`'select'`, `'columns'`, `'column'`, `'distinct'`, `'count'`, `'countDistinct'`, `'min'`, `'max'`, `'sum'`, `'sumDistinct'`, `'avg'`, `'avgDistinct'`
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query contains any specific select staments.
+
+
+
+
+#### hasEager
+
+```js
+const hasEager = queryBuilder.hasEager();
+```
+
+Returns true if the query defines any eager expressions.
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+boolean|true if the query defines any eager expressions.
 
 
 

--- a/doc/includes/CHANGELOG.md
+++ b/doc/includes/CHANGELOG.md
@@ -5,6 +5,16 @@
 ### What's new
 
   * The static [`relatedQuery`](#relatedquery) method.
+  * New reflection methods:
+    [`isFind`](http://vincit.github.io/objection.js/#isfind),
+    [`isInsert`](http://vincit.github.io/objection.js/#isinsert),
+    [`isUpdate`](http://vincit.github.io/objection.js/#isupdate),
+    [`isDelete`](http://vincit.github.io/objection.js/#isdelete),
+    [`isRelate`](http://vincit.github.io/objection.js/#isrelate),
+    [`isUnrelate`](http://vincit.github.io/objection.js/#isunrelate),
+    [`hasWheres`](http://vincit.github.io/objection.js/#haswheres),
+    [`hasSelects`](http://vincit.github.io/objection.js/#hasselects),
+    [`hasEager`](http://vincit.github.io/objection.js/#haseager).
 
 ### Breaking changes
 
@@ -24,6 +34,11 @@
        validation errors (errors like "invalid relation expression", or "cyclic model graph") had no type, and could only be identified
        based on the existence of some weird key in `error.data`. The `error.data` is now removed from those errors and the `type` should be
        used instead. The message from the data is now stored in `error.message`.
+
+### Changes
+
+  * `isFindQuery` is renamed to [`isFind`](http://vincit.github.io/objection.js/#isfind) and deprecated.
+
 
 ## 0.9.4
 
@@ -111,7 +126,7 @@
   * New shorthand methods [`joinEager`](http://vincit.github.io/objection.js/#joineager), [`naiveEager`](http://vincit.github.io/objection.js/#naiveeager),
     [`mergeJoinEager`](http://vincit.github.io/objection.js/#mergejoineager) and [`mergeNaiveEager`](http://vincit.github.io/objection.js/#mergenaiveeager).
   * New shorthand method [`findOne`](http://vincit.github.io/objection.js/#findone)
-  * New reflection method [`isFindQuery`](http://vincit.github.io/objection.js/#isfindquery)
+  * New reflection method [`isFindQuery`](http://vincit.github.io/objection.js/#isfind)
   * ManyToMany extra properties can now be updated [#413](https://github.com/Vincit/objection.js/issues/413)
 
 ## 0.8.3

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -15,6 +15,8 @@ const FindOperation = require('./operations/FindOperation');
 const DeleteOperation = require('./operations/DeleteOperation');
 const UpdateOperation = require('./operations/UpdateOperation');
 const InsertOperation = require('./operations/InsertOperation');
+const RelateOperation = require('./operations/RelateOperation');
+const UnrelateOperation = require('./operations/UnrelateOperation');
 
 const InsertGraphAndFetchOperation = require('./operations/InsertGraphAndFetchOperation');
 const UpsertGraphAndFetchOperation = require('./operations/UpsertGraphAndFetchOperation');
@@ -365,12 +367,60 @@ class QueryBuilder extends QueryBuilderBase {
     return this._resultModelClass || this.modelClass();
   }
 
+  isFind() {
+    return !(
+      this.isInsert() ||
+      this.isUpdate() ||
+      this.isDelete() ||
+      this.isRelate() ||
+      this.isUnrelate()
+    );
+  }
+
+  isInsert() {
+    return this.has(InsertOperation);
+  }
+
+  isUpdate() {
+    return this.has(UpdateOperation);
+  }
+
+  isDelete() {
+    return this.has(DeleteOperation);
+  }
+
+  isRelate() {
+    return this.has(RelateOperation);
+  }
+
+  isUnrelate() {
+    return this.has(UnrelateOperation);
+  }
+
+  hasWheres() {
+    return this.has(QueryBuilderBase.WhereSelector);
+  }
+
+  hasSelects() {
+    return this.has(QueryBuilderBase.SelectSelector);
+  }
+
+  hasEager() {
+    return !!this._eagerExpression;
+  }
+
   isFindQuery() {
-    return !this._operations.some(op => op.isWriteOperation) && !this._explicitRejectValue;
+    console.warn(
+      `isFindQuery is deprecated. Use isFind instead. This method will be removed in version 2.0`
+    );
+    return this.isFind();
   }
 
   isEagerQuery() {
-    return !!this._eagerExpression;
+    console.warn(
+      `isEagerQuery is deprecated. Use hasEager instead. This method will be removed in version 2.0`
+    );
+    return this.hasEager();
   }
 
   toString() {
@@ -502,13 +552,13 @@ class QueryBuilder extends QueryBuilderBase {
     // Take a clone so that we don't modify this instance during build.
     const builder = this.clone();
 
-    if (builder.isFindQuery()) {
+    if (builder.isFind()) {
       // If no write operations have been called at this point this query is a
       // find query and we need to call the custom find implementation.
       addFindOperation(builder);
     }
 
-    if (builder.isEagerQuery()) {
+    if (builder.hasEager()) {
       // If the query is an eager query, add the eager operation only at
       // this point of the query execution.
       addEagerFetchOperation(builder);
@@ -1062,13 +1112,13 @@ function findQueryExecutorOperation(builder) {
 function beforeExecute(builder) {
   let promise = Promise.resolve();
 
-  if (builder.isFindQuery()) {
+  if (builder.isFind()) {
     // If no write operations have been called at this point this query is a
     // find query and we need to call the custom find implementation.
     addFindOperation(builder);
   }
 
-  if (builder.isEagerQuery()) {
+  if (builder.hasEager()) {
     // If the query is an eager query, add the eager operation only at
     // this point of the query execution.
     addEagerFetchOperation(builder);
@@ -1269,7 +1319,7 @@ function shouldBeConvertedToModel(obj, modelClass) {
 }
 
 function writeOperation(builder, cb) {
-  if (!builder.isFindQuery()) {
+  if (!builder.isFind()) {
     return builder.reject(
       new Error(
         'Double call to a write method. ' +
@@ -1307,11 +1357,11 @@ function patchOperationFactory() {
 }
 
 function relateOperationFactory() {
-  return new QueryBuilderOperation('relate');
+  return new RelateOperation('relate', {});
 }
 
 function unrelateOperationFactory() {
-  return new QueryBuilderOperation('unrelate');
+  return new UnrelateOperation('unrelate', {});
 }
 
 function deleteOperationFactory() {

--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -16,7 +16,7 @@ const WhereJsonFieldPostgresOperation = require('./operations/jsonApi/WhereJsonF
 const WhereJsonNotObjectPostgresOperation = require('./operations/jsonApi/WhereJsonNotObjectPostgresOperation');
 
 const SelectSelector = SelectOperation;
-const WhereSelector = /where|orWhere|andWhere/;
+const WhereSelector = /^(where|orWhere|andWhere)/;
 const FromSelector = /^(from|into|table)$/;
 
 class QueryBuilderBase extends QueryBuilderOperationSupport {

--- a/lib/queryBuilder/QueryBuilderOperationSupport.js
+++ b/lib/queryBuilder/QueryBuilderOperationSupport.js
@@ -154,10 +154,23 @@ class QueryBuilderOperationSupport {
   forEachOperation(operationSelector, callback, match) {
     match = match == null ? true : match;
 
+    let check;
     if (operationSelector instanceof RegExp) {
-      forEachOperationRegex(this._operations, operationSelector, callback, match);
+      check = op => operationSelector.test(op.name);
+    } else if (typeof operationSelector === 'string') {
+      check = op => op.name === operationSelector;
     } else {
-      forEachOperationInstanceOf(this._operations, operationSelector, callback, match);
+      check = op => op.is(operationSelector);
+    }
+
+    for (let i = 0, l = this._operations.length; i < l; ++i) {
+      const op = this._operations[i];
+
+      if (check(op) === match) {
+        if (callback(op, i) === false) {
+          break;
+        }
+      }
     }
 
     return this;
@@ -261,30 +274,6 @@ class QueryBuilderOperationSupport {
   skipUndefined() {
     this._context.options.skipUndefined = true;
     return this;
-  }
-}
-
-function forEachOperationRegex(operations, operationSelector, callback, match) {
-  for (let i = 0, l = operations.length; i < l; ++i) {
-    const op = operations[i];
-
-    if (operationSelector.test(op.name) === match) {
-      if (callback(op, i) === false) {
-        break;
-      }
-    }
-  }
-}
-
-function forEachOperationInstanceOf(operations, operationSelector, callback, match) {
-  for (let i = 0, l = operations.length; i < l; ++i) {
-    const op = operations[i];
-
-    if (op.is(operationSelector) === match) {
-      if (callback(op, i) === false) {
-        break;
-      }
-    }
   }
 }
 

--- a/lib/queryBuilder/operations/DelegateOperation.js
+++ b/lib/queryBuilder/operations/DelegateOperation.js
@@ -7,7 +7,6 @@ class DelegateOperation extends QueryBuilderOperation {
     super(name, opt);
 
     this.delegate = opt.delegate;
-    this.isWriteOperation = this.delegate && this.delegate.isWriteOperation;
   }
 
   is(OperationClass) {

--- a/lib/queryBuilder/operations/DeleteOperation.js
+++ b/lib/queryBuilder/operations/DeleteOperation.js
@@ -1,11 +1,6 @@
 const QueryBuilderOperation = require('./QueryBuilderOperation');
 
 class DeleteOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-    this.isWriteOperation = true;
-  }
-
   onBuildKnex(knexBuilder) {
     knexBuilder.delete();
   }

--- a/lib/queryBuilder/operations/InsertOperation.js
+++ b/lib/queryBuilder/operations/InsertOperation.js
@@ -10,7 +10,6 @@ class InsertOperation extends QueryBuilderOperation {
     this.models = null;
     this.isArray = false;
     this.modelOptions = Object.assign({}, this.opt.modelOptions || {});
-    this.isWriteOperation = true;
   }
 
   onAdd(builder, args) {

--- a/lib/queryBuilder/operations/QueryBuilderOperation.js
+++ b/lib/queryBuilder/operations/QueryBuilderOperation.js
@@ -14,7 +14,6 @@ class QueryBuilderOperation {
   constructor(name, opt) {
     this.name = name;
     this.opt = opt || {};
-    this.isWriteOperation = false;
   }
 
   is(OperationClass) {

--- a/lib/queryBuilder/operations/RelateOperation.js
+++ b/lib/queryBuilder/operations/RelateOperation.js
@@ -1,0 +1,14 @@
+const QueryBuilderOperation = require('./QueryBuilderOperation');
+
+class RelateOperation extends QueryBuilderOperation {
+  constructor(name, opt) {
+    super(name, opt);
+
+    this.relation = opt.relation;
+    this.owner = opt.owner;
+    this.input = null;
+    this.ids = null;
+  }
+}
+
+module.exports = RelateOperation;

--- a/lib/queryBuilder/operations/UnrelateOperation.js
+++ b/lib/queryBuilder/operations/UnrelateOperation.js
@@ -1,0 +1,12 @@
+const QueryBuilderOperation = require('./QueryBuilderOperation');
+
+class UnrelateOperation extends QueryBuilderOperation {
+  constructor(name, opt) {
+    super(name, opt);
+
+    this.relation = opt.relation;
+    this.owner = opt.owner;
+  }
+}
+
+module.exports = UnrelateOperation;

--- a/lib/queryBuilder/operations/UpdateOperation.js
+++ b/lib/queryBuilder/operations/UpdateOperation.js
@@ -10,7 +10,6 @@ class UpdateOperation extends QueryBuilderOperation {
 
     this.model = null;
     this.modelOptions = Object.assign({}, this.opt.modelOptions || {});
-    this.isWriteOperation = true;
   }
 
   onAdd(builder, args) {

--- a/lib/relations/belongsToOne/BelongsToOneRelateOperation.js
+++ b/lib/relations/belongsToOne/BelongsToOneRelateOperation.js
@@ -1,17 +1,7 @@
 const normalizeIds = require('../../utils/normalizeIds');
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const RelateOperation = require('../../queryBuilder/operations/RelateOperation');
 
-class BelongsToOneRelateOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-    this.input = null;
-    this.ids = null;
-  }
-
+class BelongsToOneRelateOperation extends RelateOperation {
   onAdd(builder, args) {
     this.input = args[0];
     this.ids = normalizeIds(args[0], this.relation.relatedProp, { arrayOutput: true });

--- a/lib/relations/belongsToOne/BelongsToOneUnrelateOperation.js
+++ b/lib/relations/belongsToOne/BelongsToOneUnrelateOperation.js
@@ -1,6 +1,6 @@
-const BelongsToOneRelateOperation = require('./BelongsToOneRelateOperation');
+const UnrelateOperation = require('../../queryBuilder/operations/UnrelateOperation');
 
-class BelongsToOneUnrelateOperation extends BelongsToOneRelateOperation {
+class BelongsToOneUnrelateOperation extends UnrelateOperation {
   onAdd(builder, args) {
     const ids = new Array(this.relation.ownerProp.size);
 
@@ -10,6 +10,27 @@ class BelongsToOneUnrelateOperation extends BelongsToOneRelateOperation {
 
     this.ids = [ids];
     return true;
+  }
+
+  queryExecutor(builder) {
+    // NOTE: This is identical to BelongsToOneRelateOperation.queryExecutor()
+    const patch = {};
+    const ownerProp = this.relation.ownerProp;
+    const idColumn = builder.fullIdColumnFor(this.relation.ownerModelClass);
+
+    for (let i = 0, l = ownerProp.size; i < l; ++i) {
+      const relatedValue = this.ids[0][i];
+
+      ownerProp.setProp(this.owner, i, relatedValue);
+      ownerProp.patch(patch, i, relatedValue);
+    }
+
+    return this.relation.ownerModelClass
+      .query()
+      .childQueryOf(builder)
+      .copyFrom(builder, builder.constructor.WhereSelector)
+      .patch(patch)
+      .whereComposite(idColumn, this.owner.$id());
   }
 }
 

--- a/lib/relations/hasMany/HasManyRelateOperation.js
+++ b/lib/relations/hasMany/HasManyRelateOperation.js
@@ -1,17 +1,7 @@
 const normalizeIds = require('../../utils/normalizeIds');
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const RelateOperation = require('../../queryBuilder/operations/RelateOperation');
 
-class HasManyRelateOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-    this.input = null;
-    this.ids = null;
-  }
-
+class HasManyRelateOperation extends RelateOperation {
   onAdd(builder, args) {
     this.input = args[0];
     this.ids = normalizeIds(args[0], this.relation.relatedModelClass.getIdRelationProperty(), {

--- a/lib/relations/hasMany/HasManyUnrelateOperation.js
+++ b/lib/relations/hasMany/HasManyUnrelateOperation.js
@@ -1,15 +1,6 @@
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const UnrelateOperation = require('../../queryBuilder/operations/UnrelateOperation');
 
-class HasManyUnrelateOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-    this.ids = null;
-  }
-
+class HasManyUnrelateOperation extends UnrelateOperation {
   queryExecutor(builder) {
     const patch = {};
     const ownerProp = this.relation.ownerProp;

--- a/lib/relations/manyToMany/ManyToManyRelateOperation.js
+++ b/lib/relations/manyToMany/ManyToManyRelateOperation.js
@@ -1,17 +1,7 @@
 const normalizeIds = require('../../utils/normalizeIds');
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const RelateOperation = require('../../queryBuilder/operations/RelateOperation');
 
-class ManyToManyRelateOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-    this.input = null;
-    this.ids = null;
-  }
-
+class ManyToManyRelateOperation extends RelateOperation {
   onAdd(builder, args) {
     this.input = args[0];
     this.ids = normalizeIds(args[0], this.relation.relatedProp);

--- a/lib/relations/manyToMany/ManyToManyUnrelateOperation.js
+++ b/lib/relations/manyToMany/ManyToManyUnrelateOperation.js
@@ -1,14 +1,6 @@
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const UnrelateOperation = require('../../queryBuilder/operations/UnrelateOperation');
 
-class ManyToManyUnrelateOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-  }
-
+class ManyToManyUnrelateOperation extends UnrelateOperation {
   queryExecutor(builder) {
     const relatedRefs = this.relation.relatedProp.refs(builder);
     const joinTableOwnerRefs = this.relation.joinTableOwnerProp.refs(builder);

--- a/lib/relations/manyToMany/ManyToManyUnrelateSqliteOperation.js
+++ b/lib/relations/manyToMany/ManyToManyUnrelateSqliteOperation.js
@@ -1,15 +1,7 @@
-const QueryBuilderOperation = require('../../queryBuilder/operations/QueryBuilderOperation');
+const UnrelateOperation = require('../../queryBuilder/operations/UnrelateOperation');
 const SQLITE_BUILTIN_ROW_ID = '_rowid_';
 
-class ManyToManyUnrelateSqliteOperation extends QueryBuilderOperation {
-  constructor(name, opt) {
-    super(name, opt);
-
-    this.isWriteOperation = true;
-    this.relation = opt.relation;
-    this.owner = opt.owner;
-  }
-
+class ManyToManyUnrelateSqliteOperation extends UnrelateOperation {
   queryExecutor(builder) {
     const joinTableAlias = this.relation.joinTableAlias(builder);
     const joinTableAsAlias = this.relation.joinTable + ' as ' + joinTableAlias;

--- a/tests/integration/upsertGraph.js
+++ b/tests/integration/upsertGraph.js
@@ -139,7 +139,7 @@ module.exports = session => {
             // Sort all result by id to make the SQL we test below consistent.
             .mergeContext({
               onBuild(builder) {
-                if (!builder.isFindQuery()) {
+                if (!builder.isFind()) {
                   return;
                 }
 
@@ -575,7 +575,7 @@ module.exports = session => {
             // Sort all result by id to make the SQL we test below consistent.
             .mergeContext({
               onBuild(builder) {
-                if (!builder.isFindQuery()) {
+                if (!builder.isFind()) {
                   return;
                 }
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -753,7 +753,15 @@ declare namespace Objection {
     resolve(value: any): this;
 
     isExecutable(): boolean;
-    isFindQuery(): boolean;
+    isFind(): boolean;
+    isInsert(): boolean;
+    isUpdate(): boolean;
+    isDelete(): boolean;
+    isRelate(): boolean;
+    isUnrelate(): boolean;
+    hasWheres(): boolean;
+    hasSelects(): boolean;
+    hasEager(): boolean;
 
     runBefore(fn: (result: any, builder: this) => any): this;
     onBuild(fn: (builder: this) => void): this;


### PR DESCRIPTION
As discussed, this PR adds `has(str), isFind(), isInsert(), isUpdate(), isDelete(), isRelate(), isUnrelate(), hasWheres(), hasSelects(), hasEager()`

It also addresses issue #734, since that's a requirement for this to work.

- This is work in progress, submitted for review, feedback, and further work.
- Unit tests are currently missing.
- API and docs changes are currently missing.

I will add some comments on code lines in the commit itself.