### PR TITLE
Adopt getTempColumn instead of buggy name replace

### DIFF
--- a/lib/queryBuilder/operations/whereInComposite/WhereInCompositeMsSqlOperation.js
+++ b/lib/queryBuilder/operations/whereInComposite/WhereInCompositeMsSqlOperation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ObjectionToKnexConvertingOperation = require('../ObjectionToKnexConvertingOperation');
+const { getTempColumn } = require('../../../utils/tmpColumnUtils');
 const zipObject = require('lodash/zipObject');
 const flatten = require('lodash/flatten');
 
@@ -26,7 +27,7 @@ class WhereInCompositeMsSqlOperation extends ObjectionToKnexConvertingOperation 
   }
 
   buildComposite(knex, knexBuilder, columns, values) {
-    const helperColumns = columns.map(column => `:${column.replace(/\./g, ':')}`);
+    const helperColumns = columns.map((_, index) => getTempColumn(index));
 
     if (Array.isArray(values)) {
       this.buildCompositeValue(knex, knexBuilder, columns, helperColumns, values);


### PR DESCRIPTION
As highlighted by @tankers746 in https://github.com/Vincit/objection.js/pull/677, there are some queries made by Objection that work with `ref`s instead of column names. I didn't run into the issue myself, until I made a ManyToManyRelation with composite columns (which is a very good way to test the feature for the future), while @tankers746 was running into issues with upsertGraph but couldn't replicate.

The solution is to just throw out "meaningful column names". They were there just for aesthetics and are too prone to these kinds of errors, especially with more complex raw queries.