### PR TITLE
Fixes #772

### DIFF
--- a/examples/express-es6/package.json
+++ b/examples/express-es6/package.json
@@ -17,10 +17,10 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "express-promise-router": "^3.0.1",
-    "knex": "^0.14.2",
+    "knex": "^0.13.",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.4",
+    "objection": "^1.0.0-rc.11",
     "sqlite3": "^3.1.13"
   }
 }

--- a/examples/express-es6/package.json
+++ b/examples/express-es6/package.json
@@ -13,14 +13,14 @@
   "author": "Sami Koskimäki",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.17.0",
+    "axios": "^0.17.1",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
-    "express-promise-router": "^2.0.0",
-    "knex": "^0.13.0",
+    "express-promise-router": "^3.0.1",
+    "knex": "^0.14.2",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.0",
+    "objection": "^0.9.4",
     "sqlite3": "^3.1.13"
   }
 }

--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -24,14 +24,14 @@
   "author": "Sami Koskimäki",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.17.0",
+    "axios": "^0.17.1",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
-    "express-promise-router": "^2.0.0",
-    "knex": "^0.13.0",
+    "express-promise-router": "^3.0.1",
+    "knex": "^0.14.2",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.0",
+    "objection": "^0.9.4",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {

--- a/examples/express-es7/package.json
+++ b/examples/express-es7/package.json
@@ -28,10 +28,10 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "express-promise-router": "^3.0.1",
-    "knex": "^0.14.2",
+    "knex": "^0.13.",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.4",
+    "objection": "^1.0.0-rc.11",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {

--- a/examples/express-ts/package.json
+++ b/examples/express-ts/package.json
@@ -17,25 +17,24 @@
   "dependencies": {
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
-    "express-promise-router": "^2.0.0",
+    "express-promise-router": "^3.0.1",
     "knex": "^0.14.2",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^0.9.4",
+    "objection": "^1.0.0-rc.10",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {
     "@types/body-parser": "^1.16.8",
     "@types/express": "^4.11.0",
-    "@types/express-promise-router": "^2.0.0",
-    "@types/knex": "^0.0.68",
-    "@types/lodash": "^4.14.91",
+    "@types/knex": "^0.14.5",
+    "@types/lodash": "^4.14.99",
     "@types/morgan": "^1.7.35",
     "@types/sqlite3": "^3.1.1",
     "axios": "^0.17.1",
     "chai": "^4.1.2",
     "mocha": "^5.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "^2.6.2"
+    "typescript": "^2.7.1"
   }
 }

--- a/examples/express-ts/package.json
+++ b/examples/express-ts/package.json
@@ -18,10 +18,10 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "express-promise-router": "^3.0.1",
-    "knex": "^0.14.2",
+    "knex": "^0.13.",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "^1.0.0-rc.10",
+    "objection": "../..",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {

--- a/examples/express-ts/package.json
+++ b/examples/express-ts/package.json
@@ -21,7 +21,7 @@
     "knex": "^0.13.",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "objection": "../..",
+    "objection": "^1.0.0-rc.11",
     "sqlite3": "^3.1.13"
   },
   "devDependencies": {

--- a/examples/express-ts/src/app.ts
+++ b/examples/express-ts/src/app.ts
@@ -1,7 +1,6 @@
 import registerApi from './api';
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
-import * as promiseRouter from 'express-promise-router';
 import * as Knex from 'knex';
 import * as morgan from 'morgan';
 import { Model } from 'objection';
@@ -18,7 +17,8 @@ knex.migrate.latest();
 // the Model.bindKnex method.
 Model.knex(knex);
 
-const router = promiseRouter();
+// Unfortunately the express-promise-router types are borked. Just require():
+const router = require('express-promise-router')();
 const app = express()
   .use(bodyParser.json())
   .use(morgan('dev'))

--- a/examples/express-ts/src/models/Animal.ts
+++ b/examples/express-ts/src/models/Animal.ts
@@ -3,9 +3,12 @@ import Person from './Person';
 import { join } from 'path';
 
 export default class Animal extends Model {
+  // prettier-ignore
   readonly id!: number;
   ownerId?: number;
+  // prettier-ignore
   name!: string;
+  // prettier-ignore
   species!: string;
 
   // Optional eager relations.

--- a/examples/express-ts/src/models/Animal.ts
+++ b/examples/express-ts/src/models/Animal.ts
@@ -3,13 +3,13 @@ import Person from './Person';
 import { join } from 'path';
 
 export default class Animal extends Model {
-  readonly id: number;
-  ownerId: number | null;
-  name: string;
-  species: string;
+  readonly id!: number;
+  ownerId?: number;
+  name!: string;
+  species!: string;
 
   // Optional eager relations.
-  owner?: Partial<Person>;
+  owner?: Person;
 
   // Table name is the only required property.
   static tableName = 'Animal';

--- a/examples/express-ts/src/models/Movie.ts
+++ b/examples/express-ts/src/models/Movie.ts
@@ -3,11 +3,11 @@ import Person from './Person';
 import { join } from 'path';
 
 export default class Movie extends Model {
-  readonly id: number;
-  name: string;
+  readonly id!: number;
+  name?: string;
 
   // Optional eager relations.
-  actors?: Partial<Person>[];
+  actors?: Person[];
 
   // Table name is the only required property.
   static tableName = 'Movie';

--- a/examples/express-ts/src/models/Person.ts
+++ b/examples/express-ts/src/models/Person.ts
@@ -10,6 +10,7 @@ export interface Address {
 }
 
 export default class Person extends Model {
+  // prettier-ignore
   readonly id!: number;
   parentId?: number ;
   firstName?: string;

--- a/examples/express-ts/src/models/Person.ts
+++ b/examples/express-ts/src/models/Person.ts
@@ -10,20 +10,20 @@ export interface Address {
 }
 
 export default class Person extends Model {
-  readonly id: number;
-  parentId: number | null;
-  firstName: string;
-  lastName: string;
-  age: number;
-  address: Address;
-  createdAt: Date;
-  updatedAt: Date;
+  readonly id!: number;
+  parentId?: number ;
+  firstName?: string;
+  lastName?: string;
+  age?: number;
+  address?: Address;
+  createdAt?: Date;
+  updatedAt?: Date;
 
   // Optional eager relations.
-  parent?: Partial<Person>;
-  children?: Partial<Person>[];
-  pets?: Partial<Animal>[];
-  movies?: Partial<Movie>[];
+  parent?: Person;
+  children?: Person[];
+  pets?: Animal[];
+  movies?: Movie[];
 
   // Table name is the only required property.
   static tableName = 'Person';

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "types": "./typings/objection/index.d.ts",
   "dependencies": {
-    "ajv": "^6.0.1",
+    "ajv": "^6.1.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4"
   },
@@ -64,24 +64,24 @@
     "knex": "0.x"
   },
   "devDependencies": {
-    "@types/knex": "^0.0.67",
-    "@types/node": "^8.0.57",
-    "babel-eslint": "^8.0.1",
+    "@types/knex": "^0.14.5",
+    "@types/node": "^9.4.0",
+    "babel-eslint": "^8.2.1",
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
     "coveralls": "^3.0.0",
-    "eslint": "^4.10.0",
-    "eslint-plugin-prettier": "^2.3.1",
+    "eslint": "^4.16.0",
+    "eslint-plugin-prettier": "^2.5.0",
     "expect.js": "^0.3.1",
-    "fs-extra": "5.0.0",
-    "glob": "^7.1.1",
+    "fs-extra": "^5.0.0",
+    "glob": "^7.1.2",
     "istanbul": "^0.4.5",
     "knex": "0.x",
-    "mocha": "^4.0.1",
-    "mysql": "^2.13.0",
-    "pg": "^7.4.0",
-    "prettier": "^1.9.1",
-    "sqlite3": "3.1.13",
-    "typescript": "2.6.2"
+    "mocha": "^5.0.0",
+    "mysql": "^2.15.0",
+    "pg": "^7.4.1",
+    "prettier": "^1.10.2",
+    "sqlite3": "^3.1.13",
+    "typescript": "^2.7.1"
   }
 }

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -38,13 +38,16 @@ class CustomValidator extends objection.Validator {
 }
 
 class Person extends objection.Model {
-  firstName: string;
-  lastName: string;
-  mom: Person;
-  children: Person[];
-  pets: Animal[];
-  comments: Comment[];
-  movies: Movie[];
+  // With TypeScript 2.7, fields in models need either optionality:
+  firstName?: string;
+  // Or for not-null fields that are always initialized, you can use the new ! syntax:
+  lastName!: string;
+  mom?: Person;
+  children?: Person[];
+  // Note that $relatedQuery won't work for optional fields (at least until TS 2.8), so this gets a !:
+  pets!: Animal[];
+  comments?: Comment[];
+  movies?: Movie[];
 
   static columnNameMappers = objection.snakeCaseMappers();
 
@@ -160,9 +163,9 @@ async () => {
 };
 
 class Movie extends objection.Model {
-  title: string;
-  actors: Person[];
-  director: Person;
+  title!: string;
+  actors!: Person[];
+  director!: Person;
 
   /**
    * This static field instructs Objection how to hydrate and persist
@@ -211,7 +214,7 @@ const relatedPersons: Promise<Person[]> = new Person().$relatedQuery('children')
 const relatedMovies: Promise<Person[]> = new Movie().$relatedQuery('actors');
 
 class Animal extends objection.Model {
-  species: string;
+  species!: string;
 
   // Tests the ColumnNameMappers interface.
   static columnNameMappers = {
@@ -226,7 +229,7 @@ class Animal extends objection.Model {
 }
 
 class Comment extends objection.Model {
-  comment: string;
+  comment!: string;
 }
 
 // !!! see examples/express-ts/src/app.ts for a valid knex setup. The following is bogus:
@@ -268,7 +271,7 @@ const appendRelatedPerson: Person = examplePerson.$appendRelated('pets', [
 const people: Promise<Person[]> = Person.loadRelated([new Person()], 'movies');
 
 class Actor {
-  canAct: boolean;
+  canAct?: boolean;
 }
 
 // Optional<Person> typing for findById():
@@ -289,7 +292,8 @@ function whereSpecies(species: string): Promise<Animal[]> {
   return Animal.query().where('species', species);
 }
 
-const personPromise: Promise<Person> = objection.QueryBuilder.forClass(Person).findById(1);
+const pqb: objection.QueryBuilder<Person> = objection.QueryBuilder.forClass(Person)
+const personPromise: Promise<Person | undefined> = pqb.findById(1);
 
 // QueryBuilder.findById accepts single and array values:
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -241,15 +241,15 @@ declare namespace Objection {
    */
   type RelationExpression = string;
 
-  interface FilterFunction<QM> {
+  interface FilterFunction<QM extends Model> {
     (queryBuilder: QueryBuilder<QM, QM[]>): void;
   }
 
-  interface FilterExpression<QM> {
+  interface FilterExpression<QM extends Model> {
     [namedFilter: string]: FilterFunction<QM>;
   }
 
-  interface RelationExpressionMethod<QM, RM, RV> {
+  interface RelationExpressionMethod<QM extends Model, RM, RV> {
     (relationExpression: RelationExpression): QueryBuilder<QM, RM, RV>;
   }
 
@@ -274,27 +274,27 @@ declare namespace Objection {
   }
 
   interface JoinRelation {
-    <QM>(relationName: string, opt?: RelationOptions): QueryBuilder<QM, QM[]>;
+    <QM extends Model>(relationName: string, opt?: RelationOptions): QueryBuilder<QM, QM[]>;
   }
 
   type JsonObjectOrFieldExpression = object | object[] | FieldExpression;
 
-  interface WhereJson<QM, RM, RV> {
+  interface WhereJson<QM extends Model, RM, RV> {
     (
       fieldExpression: FieldExpression,
       jsonObjectOrFieldExpression: JsonObjectOrFieldExpression
     ): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereFieldExpression<QM, RM, RV> {
+  interface WhereFieldExpression<QM extends Model, RM, RV> {
     (fieldExpression: FieldExpression): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereJsonExpression<QM, RM, RV> {
+  interface WhereJsonExpression<QM extends Model, RM, RV> {
     (fieldExpression: FieldExpression, keys: string | string[]): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereJsonField<QM, RM, RV> {
+  interface WhereJsonField<QM extends Model, RM, RV> {
     (
       fieldExpression: FieldExpression,
       operator: string,
@@ -302,8 +302,8 @@ declare namespace Objection {
     ): QueryBuilder<QM, RM, RV>;
   }
 
-  interface ModifyEager<QM1, RM1, RV1> {
-    <QM2>(
+  interface ModifyEager<QM1 extends Model, RM1, RV1> {
+    <QM2 extends Model>(
       relationExpression: string | RelationExpression,
       modifier: (builder: QueryBuilder<QM2, QM2[]>) => void
     ): QueryBuilder<QM1, RM1, RV1>;
@@ -317,7 +317,7 @@ declare namespace Objection {
     (err: any, result?: any): void;
   }
 
-  interface Filters<QM> {
+  interface Filters<QM extends Model> {
     [filterName: string]: (queryBuilder: QueryBuilder<QM, QM[]>) => void;
   }
 
@@ -380,7 +380,7 @@ declare namespace Objection {
       expression: RelationExpression,
       filters?: Filters<M>,
       trxOrKnex?: Transaction | knex
-    ): Promise<M[]>;
+    ): Promise<(Model | object)[]>;
 
     traverse(
       filterConstructor: typeof Model,
@@ -425,7 +425,7 @@ declare namespace Objection {
     static WhereInEagerAlgorithm: EagerAlgorithm;
     static NaiveEagerAlgorithm: EagerAlgorithm;
 
-    static query<QM>(this: Constructor<QM>, trxOrKnex?: Transaction | knex): QueryBuilder<QM, QM[]>;
+    static query<QM extends Model>(this: Constructor<QM>, trxOrKnex?: Transaction | knex): QueryBuilder<QM, QM[]>;
     // This can only be used as a subquery so the result model type is irrelevant.
     static relatedQuery(relationName: string): QueryBuilder<any, any[]>;
     static knex(knex?: knex): knex;
@@ -441,7 +441,7 @@ declare namespace Objection {
 
     static omitImpl(f: (obj: object, prop: string) => void): void;
 
-    static loadRelated<QM>(
+    static loadRelated<QM extends Model>(
       this: Constructor<QM>,
       models: (QM | object)[],
       expression: RelationExpression,
@@ -470,26 +470,27 @@ declare namespace Objection {
     $formatDatabaseJson(json: Pojo): Pojo;
     $parseJson(json: Pojo, opt?: ModelOptions): Pojo;
     $formatJson(json: Pojo): Pojo;
-    $setJson(json: Pojo, opt?: ModelOptions): this;
-    $setDatabaseJson(json: Pojo): this;
+    $setJson<M>(this: M, json: Pojo, opt?: ModelOptions): M;
+    $setDatabaseJson<M>(this: M, json: Pojo): M;
     $setRelated<RelatedM extends Model>(
       relation: String | Relation,
       related: RelatedM | RelatedM[] | null | undefined
     ): this;
-    $appendRelated<RelatedM extends Model>(
+    $appendRelated<M, RelatedM extends Model>(
+      this: M,
       relation: String | Relation,
       related: RelatedM | RelatedM[] | null | undefined
-    ): this;
+    ): M;
 
-    $set(obj: Pojo): this;
-    $omit(keys: string | string[] | Properties): this;
-    $pick(keys: string | string[] | Properties): this;
-    $clone(opt?: CloneOptions): this;
+    $set<M>(this: M, obj: Pojo): M;
+    $omit<M>(this: M, keys: string | string[] | Properties): M;
+    $pick<M>(this: M, keys: string | string[] | Properties): M;
+    $clone<M>(this: M, opt?: CloneOptions): M;
 
     /**
      * AKA `reload` in ActiveRecord parlance
      */
-    $query(trxOrKnex?: Transaction | knex): QueryBuilder<this, this>;
+    $query<M extends Model>(this: M, trxOrKnex?: Transaction | knex): QueryBuilder<M, M>;
 
     /**
      * If you add fields to your model, you get $relatedQuery typings for
@@ -499,7 +500,7 @@ declare namespace Objection {
      * though, you should apply a cast, which will make your code use not this
      * signatue, but the following signature.
      */
-    $relatedQuery<K extends keyof this, V extends this[K]>(
+    $relatedQuery<K extends keyof this, V extends this[K] & Model>(
       relationName: K,
       trxOrKnex?: Transaction | knex
     ): QueryBuilder<V, V, V>;
@@ -513,11 +514,11 @@ declare namespace Objection {
       trxOrKnex?: Transaction | knex
     ): QueryBuilder<QM, RM>;
 
-    $loadRelated<QM>(
+    $loadRelated<M extends Model, QM extends Model>(this: M,
       expression: keyof this | RelationExpression,
       filters?: Filters<QM>,
       trxOrKnex?: Transaction | knex
-    ): QueryBuilder<this, this>;
+    ): QueryBuilder<M, M>;
 
     $traverse(traverser: TraverserFunction): void;
     $traverse(filterConstructor: this, traverser: TraverserFunction): void;
@@ -534,51 +535,51 @@ declare namespace Objection {
     $afterDelete(queryContext: QueryContext): Promise<any> | void;
   }
 
-  export class QueryBuilder<QM, RM, RV> {
-    static forClass<M extends Model>(modelClass: ModelClass<M>): QueryBuilder<M>;
+  export class QueryBuilder<QM extends Model, RM, RV> {
+    static forClass<M extends Model,MC extends ModelClass<M>>(modelClass: MC): QueryBuilder<M>;
   }
 
   export interface Executable<RV> extends Promise<RV> {
     execute(): Promise<RV>;
   }
 
-  export interface QueryBuilder<QM, RM = QM[], RV = RM>
+  export interface QueryBuilder<QM extends Model, RM = QM[], RV = RM>
     extends QueryBuilderBase<QM, RM, RV>,
       Executable<RV> {
     throwIfNotFound(): QueryBuilder<QM, RM>;
   }
 
-  export interface QueryBuilderYieldingOneOrNone<QM> extends QueryBuilder<QM, QM, QM | undefined> {}
+  export interface QueryBuilderYieldingOneOrNone<QM extends Model> extends QueryBuilder<QM, QM, QM | undefined> {}
 
-  export interface QueryBuilderYieldingCount<QM, RM = QM[]>
+  export interface QueryBuilderYieldingCount<QM extends Model, RM = QM[]>
     extends QueryBuilderBase<QM, RM, number>,
       Executable<number> {
     throwIfNotFound(): this;
   }
 
-  interface Insert<QM> {
+  interface Insert<QM extends Model> {
     (modelsOrObjects?: Partial<QM>[]): QueryBuilder<QM, QM[]>;
     (modelOrObject?: Partial<QM>): QueryBuilder<QM, QM>;
     (): this;
   }
 
-  interface InsertGraph<QM> {
+  interface InsertGraph<QM extends Model> {
     (modelsOrObjects?: Partial<QM>[], options?: InsertGraphOptions): QueryBuilder<QM, QM[]>;
     (modelOrObject?: Partial<QM>, options?: InsertGraphOptions): QueryBuilder<QM, QM>;
     (): this;
   }
 
-  interface Upsert<QM> {
+  interface Upsert<QM extends Model> {
     (modelsOrObjects?: Partial<QM>[], options?: UpsertOptions): QueryBuilder<QM, QM[]>;
     (modelOrObject?: Partial<QM>, options?: UpsertOptions): QueryBuilder<QM, QM>;
   }
 
-  interface InsertGraphAndFetch<QM> {
+  interface InsertGraphAndFetch<QM extends Model> {
     (modelsOrObjects?: Partial<QM>, options?: InsertGraphOptions): QueryBuilder<QM, QM>;
     (modelsOrObjects?: Partial<QM>[], options?: InsertGraphOptions): QueryBuilder<QM, QM[]>;
   }
 
-  interface QueryBuilderBase<QM, RM, RV> extends QueryInterface<QM, RM, RV> {
+  interface QueryBuilderBase<QM extends Model, RM, RV> extends QueryInterface<QM, RM, RV> {
     modify(func: (builder: this) => void): this;
     modify(namedFilter: string): this;
 
@@ -878,7 +879,7 @@ declare namespace Objection {
   type ColumnRef = string | Raw | Reference | QueryBuilder<any, any[]>;
   type TableName = string | Raw | Reference | QueryBuilder<any, any[]>;
 
-  interface QueryInterface<QM, RM, RV> {
+  interface QueryInterface<QM extends Model, RM, RV> {
     select: Select<QM, RM, RV>;
     as: As<QM, RM, RV>;
     columns: Select<QM, RM, RV>;
@@ -1004,20 +1005,20 @@ declare namespace Objection {
     clone(): this;
   }
 
-  interface As<QM, RM, RV> {
+  interface As<QM extends Model, RM, RV> {
     (alias: string): QueryBuilder<QM, RM, RV>;
   }
 
-  interface Select<QM, RM, RV> extends ColumnNamesMethod<QM, RM, RV> {}
+  interface Select<QM extends Model, RM, RV> extends ColumnNamesMethod<QM, RM, RV> {}
 
-  interface Table<QM, RM, RV> {
+  interface Table<QM extends Model, RM, RV> {
     (tableName: TableName): QueryBuilder<QM, RM, RV>;
     (callback: (queryBuilder: QueryBuilder<QM, QM[]>) => void): QueryBuilder<QM, RM, RV>;
   }
 
-  interface Distinct<QM, RM, RV> extends ColumnNamesMethod<QM, RM, RV> {}
+  interface Distinct<QM extends Model, RM, RV> extends ColumnNamesMethod<QM, RM, RV> {}
 
-  interface Join<QM, RM, RV> {
+  interface Join<QM extends Model, RM, RV> {
     (raw: Raw): QueryBuilder<QM, RM, RV>;
     (
       tableName: TableName,
@@ -1036,19 +1037,19 @@ declare namespace Objection {
     >;
   }
 
-  interface JoinRaw<QM, RM, RV> {
+  interface JoinRaw<QM extends Model, RM, RV> {
     (sql: string, bindings?: any): QueryBuilder<QM, RM, RV>;
   }
 
-  interface With<QM, RM, RV> extends WithRaw<QM, RM, RV>, WithWrapped<QM, RM, RV> {}
+  interface With<QM extends Model, RM, RV> extends WithRaw<QM, RM, RV>, WithWrapped<QM, RM, RV> {}
 
-  interface WithRaw<QM, RM, RV> {
+  interface WithRaw<QM extends Model, RM, RV> {
     (alias: string, raw: Raw): QueryBuilder<QM, RM, RV>;
     join: knex.JoinClause;
     (alias: string, sql: string, bindings?: any): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WithWrapped<QM, RM, RV> {
+  interface WithWrapped<QM extends Model, RM, RV> {
     (alias: string, callback: (queryBuilder: QueryBuilder<QM, QM[]>) => any): QueryBuilder<
       QM,
       RM,
@@ -1056,7 +1057,7 @@ declare namespace Objection {
     >;
   }
 
-  interface Where<QM, RM, RV> extends WhereRaw<QM, RM, RV> {
+  interface Where<QM extends Model, RM, RV> extends WhereRaw<QM, RM, RV> {
     (callback: (queryBuilder: QueryBuilder<QM, QM[]>) => void): QueryBuilder<QM, RM, RV>;
     (object: object): QueryBuilder<QM, RM, RV>;
     (
@@ -1074,7 +1075,7 @@ declare namespace Objection {
     ): QueryBuilder<QM, RM, RV>;
   }
 
-  interface FindOne<QM> {
+  interface FindOne<QM extends Model> {
     (condition: boolean): QueryBuilderYieldingOneOrNone<QM>;
     (callback: (queryBuilder: QueryBuilder<QM, QM[]>) => void): QueryBuilderYieldingOneOrNone<QM>;
     (object: object): QueryBuilderYieldingOneOrNone<QM>;
@@ -1095,19 +1096,19 @@ declare namespace Objection {
     ): QueryBuilderYieldingOneOrNone<QM>;
   }
 
-  interface WhereRaw<QM, RM, RV> extends RawMethod<QM, RM, RV> {
+  interface WhereRaw<QM extends Model, RM, RV> extends RawMethod<QM, RM, RV> {
     (condition: boolean): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereWrapped<QM, RM, RV> {
+  interface WhereWrapped<QM extends Model, RM, RV> {
     (callback: (queryBuilder: QueryBuilder<QM, QM[]>) => void): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereNull<QM, RM, RV> {
+  interface WhereNull<QM extends Model, RM, RV> {
     (column: ColumnRef): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereIn<QM, RM, RV> {
+  interface WhereIn<QM extends Model, RM, RV> {
     (column: ColumnRef, values: Value[]): QueryBuilder<QM, RM, RV>;
     (
       column: ColumnRef,
@@ -1116,11 +1117,11 @@ declare namespace Objection {
     (column: ColumnRef, query: QueryBuilder<any, any[]>): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereBetween<QM, RM, RV> {
+  interface WhereBetween<QM extends Model, RM, RV> {
     (column: ColumnRef, range: [Value, Value]): QueryBuilder<QM, RM, RV>;
   }
 
-  interface WhereExists<QM, RM, RV> {
+  interface WhereExists<QM extends Model, RM, RV> {
     (
       callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void
     ): QueryBuilder<QM, RM, RV>;
@@ -1128,13 +1129,13 @@ declare namespace Objection {
     (raw: Raw): QueryBuilder<QM, RM, RV>;
   }
 
-  interface GroupBy<QM, RM, RV> extends RawMethod<QM, RM, RV>, ColumnNamesMethod<QM, RM, RV> {}
+  interface GroupBy<QM extends Model, RM, RV> extends RawMethod<QM, RM, RV>, ColumnNamesMethod<QM, RM, RV> {}
 
-  interface OrderBy<QM, RM, RV> {
+  interface OrderBy<QM extends Model, RM, RV> {
     (column: ColumnRef, direction?: string): QueryBuilder<QM, RM, RV>;
   }
 
-  interface Union<QM> {
+  interface Union<QM extends Model> {
     (callback: () => void, wrap?: boolean): QueryBuilder<QM, QM[]>;
     (callbacks: (() => void)[], wrap?: boolean): QueryBuilder<QM, QM[]>;
     (...callbacks: (() => void)[]): QueryBuilder<QM, QM[]>;
@@ -1142,12 +1143,12 @@ declare namespace Objection {
 
   // commons
 
-  interface ColumnNamesMethod<QM, RM, RV> {
+  interface ColumnNamesMethod<QM extends Model, RM, RV> {
     (...columnNames: ColumnRef[]): QueryBuilder<QM, RM, RV>;
     (columnNames: ColumnRef[]): QueryBuilder<QM, RM, RV>;
   }
 
-  interface RawMethod<QM, RM, RV> {
+  interface RawMethod<QM extends Model, RM, RV> {
     (sql: string, ...bindings: any[]): QueryBuilder<QM, RM, RV>;
     (sql: string, bindings: any): QueryBuilder<QM, RM, RV>;
     (raw: Raw): QueryBuilder<QM, RM, RV>;


### PR DESCRIPTION
* Updated all dependencies (except knex)
* Fixed optional/required model fields (TS 2.7 --strict support)
* TS 2.7 is more strict with genericized return values, but doesn't infer model types still, so many `<M>(this: M)` captures had to be used in lieu of prior `this`-returns.
* QM now always extends Model. I believe this is correct, right? Can you query on non-models?