### PR TITLE
Remove code-duplication in throwIfNotFound()

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -607,9 +607,12 @@ class QueryBuilder extends QueryBuilderBase {
 
   throwIfNotFound() {
     return this.runAfter((result, builder) => {
-      if (Array.isArray(result) && result.length === 0) {
-        throw this._modelClass.createNotFoundError(builder.context());
-      } else if (result === null || result === undefined || result === 0) {
+      if (
+        (Array.isArray(result) && result.length === 0) ||
+        result === null ||
+        result === undefined ||
+        result === 0
+      ) {
         throw this._modelClass.createNotFoundError(builder.context());
       } else {
         return result;


### PR DESCRIPTION
A possibility for a minor simplification I happened to stumble over that removes the need to write the same line of code twice (`throw this._modelClass.createNotFoundError(builder.context());`).

I think legibility remains equally good.