### PR TITLE
Do not fetch relations set to undefined in data

### DIFF
--- a/lib/queryBuilder/RelationExpression.js
+++ b/lib/queryBuilder/RelationExpression.js
@@ -303,7 +303,7 @@ function modelToNode(model, node) {
   for (let r = 0, lr = relations.length; r < lr; ++r) {
     const relName = relations[r].name;
 
-    if (model.hasOwnProperty(relName)) {
+    if (model[relName] !== undefined) {
       let childNode = node.children[relName];
 
       if (!childNode) {

--- a/tests/integration/insertGraph.js
+++ b/tests/integration/insertGraph.js
@@ -612,6 +612,17 @@ module.exports = session => {
             });
           });
       });
+
+      it('should not fetch relations that are set to undefined', () => {
+        return Model2.query()
+          .insertGraphAndFetch({
+            model2Prop1: 'foo',
+            model2Relation1: undefined
+          })
+          .then(inserted => {
+            expect(inserted).to.not.have.property('model2Relation1');
+          });
+      });
     });
 
     describe('.query().insertGraph().allowRelated()', () => {


### PR DESCRIPTION
When a value for a relation is set to `undefined` in data passed to `insertGraphAndFetch()` or `upsertGraphAndFetch()`, this relation should not be fetched after the insert / upsert operation.

A simple unit test is included to check for the correct behavior.