### PR TITLE
Doc: Add missing arg in runBefore() / runAfter()

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -2736,8 +2736,8 @@ const context = builder.context();
 Person
   .query()
   .context({
-    runBefore: (builder) => {},
-    runAfter: (builder) => {},
+    runBefore: (result, builder) => {},
+    runAfter: (result, builder) => {},
     onBuild: (builder) => {}
   });
 ```


### PR DESCRIPTION
I found this omission today while playing around with the different query hooks. After looking into all occurrences and also the way these methods are being called, I'm fairly certain that this is their correct signature.