### PR TITLE
Clarity for QueryBuilder.toString() vs .toSql() behavior

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -435,14 +435,14 @@ class QueryBuilder extends QueryBuilderBase {
 
   toString() {
     try {
-      return this.build().toString();
+      return this.toSql();
     } catch (err) {
       return `This query cannot be built synchronously. Consider using debug() method instead.`;
     }
   }
 
   toSql() {
-    return this.toString();
+    return this.build().toString();
   }
 
   clone() {


### PR DESCRIPTION
## Discussion and context

From looking at #360, I can see why [toString() was wrapped in a try-catch](https://github.com/Vincit/objection.js/commit/17ee8f1489a51ea8ea9681bacdceb5933a646c0d). In my personal opinion, I think that try-catching all exceptions is dangerous. Silently returning a phrase instead of the expected SQL is even more sketchy, but reading the thread in #360 makes it clear that most people are using toString() for logging purposes. I guess that's okay.

The problem is that `toSql()` is a direct alias of `toString()`, complete with catching every error. We use `toSql()` to pipe into a alternate database resolution layer. So in instances where we want an exception to be thrown, we must instead literally look for the phrase "This query cannot be built synchronously" to determine if an error has occurred.

## Proposed changes

This PR leaves the behavior of `toString()` the same, but will allow `toSql()` to raise exceptions as appropriate. To be more specific, it makes `toSql()` the primary method and `toString()` a method that wraps `toSql()` in a try-catch.

So the behavior is exactly the same for toString() and no changes need to be made to the code.

Without this PR, we are forced to  use `this.build().toString()` directly.