### PR TITLE
combine strict compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,13 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "alwaysStrict": true,
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noImplicitUseStrict": false,
     "strict": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
     "target": "es6"
   },
   "files": [


### PR DESCRIPTION
The "strict" option already enables `--noImplicitAny`, `--noImplicitThis`, `--alwaysStrict`, `--strictNullChecks`, `--strictFunctionTypes` and `--strictPropertyInitialization`, so there is no need to list them individually.

Reference: https://www.typescriptlang.org/docs/handbook/compiler-options.html