### PR TITLE
save stack trace to the client code in QueryBuilder and replace a stack if knex is configured with asyncStackTraces

### DIFF
--- a/examples/express-ts/src/models/Person.ts
+++ b/examples/express-ts/src/models/Person.ts
@@ -12,7 +12,7 @@ export interface Address {
 export default class Person extends Model {
   // prettier-ignore
   readonly id!: number;
-  parentId?: number ;
+  parentId?: number;
   firstName?: string;
   lastName?: string;
   age?: number;

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -43,7 +43,8 @@ const KnexOperation = require('./operations/KnexOperation');
 
 class QueryBuilder extends QueryBuilderBase {
   constructor(modelClass) {
-    super(modelClass.knex());
+    const knex = modelClass.knex();
+    super(knex);
 
     this._modelClass = modelClass;
     this._resultModelClass = null;
@@ -67,6 +68,15 @@ class QueryBuilder extends QueryBuilderBase {
     this._unrelateOperationFactory = unrelateOperationFactory;
     this._deleteOperationFactory = deleteOperationFactory;
     this._eagerOperationFactory = modelClass.defaultEagerAlgorithm;
+
+    if (knex && knex.client && knex.client.config.asyncStackTraces) {
+      // a hack to get a callstack into the client code despite this
+      // node.js bug https://github.com/nodejs/node/issues/11865
+      const stack = new Error().stack.split('\n');
+
+      stack.splice(0, 4);
+      this._asyncStack = stack;
+    }
   }
 
   static forClass(modelClass) {
@@ -474,6 +484,7 @@ class QueryBuilder extends QueryBuilderBase {
     builder._unrelateOperationFactory = this._unrelateOperationFactory;
     builder._deleteOperationFactory = this._deleteOperationFactory;
     builder._eagerOperationFactory = this._eagerOperationFactory;
+    builder._asyncStack = this._asyncStack;
 
     return builder;
   }
@@ -1227,6 +1238,14 @@ function afterExecute(builder, result) {
 }
 
 function handleExecuteError(builder, err) {
+  if (builder._asyncStack) {
+    err.originalStack = err.stack;
+    const firstLine = err.stack.split('\n')[0];
+    builder._asyncStack.unshift(firstLine);
+    // put the fake more helpful "async" stack on the thrown error
+    err.stack = builder._asyncStack.join('\n');
+  }
+
   let promise = Promise.reject(err);
 
   builder._operations.forEach(op => {

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -282,7 +282,10 @@ const appendRelatedPerson: Person = examplePerson.$appendRelated('pets', [
 ]);
 
 // static methods from Model should return the subclass type
-const personQB: objection.QueryBuilderYieldingOne<Person> = Person.loadRelated(new Person(), 'movies');
+const personQB: objection.QueryBuilderYieldingOne<Person> = Person.loadRelated(
+  new Person(),
+  'movies'
+);
 const peopleQB: objection.QueryBuilder<Person> = Person.loadRelated([new Person()], 'movies');
 
 const person: Promise<Person> = personQB;

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -579,8 +579,7 @@ declare namespace Objection {
     throwIfNotFound(): QueryBuilder<QM, RM>;
   }
 
-  export interface QueryBuilderYieldingOne<QM extends Model>
-    extends QueryBuilder<QM, QM, QM> {}
+  export interface QueryBuilderYieldingOne<QM extends Model> extends QueryBuilder<QM, QM, QM> {}
 
   export interface QueryBuilderYieldingOneOrNone<QM extends Model>
     extends QueryBuilder<QM, QM, QM | undefined> {}
@@ -588,8 +587,8 @@ declare namespace Objection {
   export interface QueryBuilderYieldingCount<QM extends Model, RM = QM[]>
     extends QueryBuilderBase<QM, RM, number>,
       Executable<number> {
-        throwIfNotFound(): this;
-      }
+    throwIfNotFound(): this;
+  }
 
   interface Insert<QM extends Model> {
     (modelsOrObjects?: Partial<QM>[]): QueryBuilder<QM, QM[]>;


### PR DESCRIPTION
this is similar thing I opened here for knex: https://github.com/tgriesser/knex/pull/2505

I reused the config from the knex client, hope that it's allright