### PR TITLE
ensureRelation returns null if relation is string

### DIFF
--- a/lib/model/modelSet.js
+++ b/lib/model/modelSet.js
@@ -169,9 +169,8 @@ function appendRelated(model, relation, models) {
 function ensureRelation(model, relation) {
   if (typeof relation === 'string') {
     relation = model.constructor.getRelation(relation);
-  } else {
-    return relation;
   }
+  return relation;
 }
 
 module.exports = {


### PR DESCRIPTION
I haven't run the test suite on this change but `$setRelated` kept erroring for me until I made this change. I feel it must be a bug, though, because the way it was written, line 171 doesn't do anything. Is there not a test case for `$setRelated('name', model)`?