### PR TITLE
Add `name` property to custom errors

### DIFF
--- a/lib/model/NotFoundError.js
+++ b/lib/model/NotFoundError.js
@@ -2,6 +2,7 @@ class NotFoundError extends Error {
   constructor(data) {
     super('NotFoundError');
 
+    this.name = this.constructor.name;
     this.data = data;
     this.statusCode = 404;
   }

--- a/lib/model/ValidationError.js
+++ b/lib/model/ValidationError.js
@@ -15,6 +15,7 @@ class ValidationError extends Error {
   constructor({ type, message, data = {}, statusCode = 400 }) {
     super(message || errorsToMessage(data));
 
+    this.name = this.constructor.name;
     this.type = type;
     this.data = data;
     this.statusCode = statusCode;

--- a/lib/relations/RelationProperty.js
+++ b/lib/relations/RelationProperty.js
@@ -10,11 +10,17 @@ const { propToStr, PROP_KEY_PREFIX } = require('../model/modelValues');
 class ModelNotFoundError extends Error {
   constructor(tableName) {
     super();
+    this.name = this.constructor.name;
     this.tableName = tableName;
   }
 }
 
-class InvalidReferenceError extends Error {}
+class InvalidReferenceError extends Error {
+  constructor() {
+    super();
+    this.name = this.constructor.name;
+  }
+}
 
 // A pair of these define how two tables are related to each other.
 // Both the owner and the related table have one of these.


### PR DESCRIPTION
If you access the `stack` property of an error, you will get a string with the first line [formatted as `<error class name>: <error message>`](https://nodejs.org/api/errors.html#errors_error_stack). Here, `<error class name>` refers to the `name` property of the error, which by default is just `Error`.

Currently, whenever you try to print the stack of a custom objection.js error, you get the string that starts with `Error: `. I think it would be preferable to get the actual name of the error instead of just `Error`.