### PR TITLE
Add transaction argument to static related query 

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -5749,7 +5749,7 @@ Type|Description
 #### relatedQuery
 
 ```js
-const queryBuilder = Person.relatedQuery(relationName);
+const queryBuilder = Person.relatedQuery(relationName, transactionOrKnex);
 ```
 
 > Select count of a relation and the maximum value of another one:
@@ -5790,6 +5790,7 @@ Creates a subquery to a relation.
 Argument|Type|Description
 --------|----|--------------------
 relationName|string|The name of the relation to create subquery for.
+transactionOrKnex|object|Optional transaction or knex instance for the query. This can be used to specify a transaction or even a different database.
 
 ##### Return value
 

--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -525,12 +525,12 @@ class Model {
     return this.QueryBuilder.forClass(this).transacting(trx);
   }
 
-  static relatedQuery(relationName) {
+  static relatedQuery(relationName, trx) {
     const relation = this.getRelation(relationName);
     const modelClass = relation.relatedModelClass;
 
     return modelClass
-      .query()
+      .query(trx)
       .alias(relation.name)
       .findOperationFactory(builder => relation.subQuery(builder));
   }

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -367,7 +367,7 @@ declare namespace Objection {
 
     query(trxOrKnex?: Transaction | knex): QueryBuilder<M, M[]>;
     // This can only be used as a subquery so the result model type is irrelevant.
-    relatedQuery(relationName: string): QueryBuilder<any, any[]>;
+    relatedQuery(relationName: string, trxOrKnex?: Transaction | knex): QueryBuilder<any, any[]>;
     knex(knex?: knex): knex;
     knexQuery(): knex.QueryBuilder;
 
@@ -445,7 +445,7 @@ declare namespace Objection {
       trxOrKnex?: Transaction | knex
     ): QueryBuilder<QM>;
     // This can only be used as a subquery so the result model type is irrelevant.
-    static relatedQuery(relationName: string): QueryBuilder<any, any[]>;
+    static relatedQuery(relationName: string, trxOrKnex?: Transaction | knex): QueryBuilder<any, any[]>;
     static knex(knex?: knex): knex;
     static knexQuery(): knex.QueryBuilder;
     static bindKnex<M>(this: M, knex: knex): M;


### PR DESCRIPTION
When using the interface, I needed that specific function signature and wondered why it didn't work, as I thought the transaction pattern worked here too, so here we go.

One thing to note: I'm not experienced in editing the documentation nor the typings, so please check those.