### PR TITLE
 Types for tableMetadata and fetchTableMetadata 

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -237,6 +237,21 @@ declare namespace Objection {
     [key: string]: any;
   }
 
+  export interface TableMetadata {
+    columns: Array<string>;
+  }
+
+  export interface TableMetadataOptions {
+    table: string;
+  }
+
+  export interface FetchTableMetadataOptions<T extends Model> {
+    parentBuilder?: QueryBuilder<T>;
+    knex?: knex;
+    force?: boolean;
+    table?: string;
+  }
+
   /**
    * @see http://vincit.github.io/objection.js/#fieldexpression
    */
@@ -403,6 +418,8 @@ declare namespace Objection {
       traverser: TraverserFunction
     ): void;
     traverse(models: Model | Model[], traverser: TraverserFunction): void;
+    tableMetadata(opt?: TableMetadataOptions): TableMetadata;
+    fetchTableMetadata(opt?: FetchTableMetadataOptions<Model>): Promise<TableMetadata>;
   }
 
   // TS 2.5 doesn't support interfaces with static methods or fields, so
@@ -484,6 +501,8 @@ declare namespace Objection {
     ): void;
     static traverse(models: Model | Model[], traverser: TraverserFunction): void;
 
+    static tableMetadata(opt?: TableMetadataOptions): TableMetadata;
+    static fetchTableMetadata(opt?: FetchTableMetadataOptions<Model>): Promise<TableMetadata>;
     // Implementation note: At least as of TypeScript 2.7, subclasses of
     // methods that return `this` are not compatible with their superclass.
     // For example, `class Movie extends Model` could not be passed as a

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -245,8 +245,8 @@ declare namespace Objection {
     table: string;
   }
 
-  export interface FetchTableMetadataOptions<T extends Model> {
-    parentBuilder?: QueryBuilder<T>;
+  export interface FetchTableMetadataOptions {
+    parentBuilder?: QueryBuilder<Model>;
     knex?: knex;
     force?: boolean;
     table?: string;
@@ -419,7 +419,7 @@ declare namespace Objection {
     ): void;
     traverse(models: Model | Model[], traverser: TraverserFunction): void;
     tableMetadata(opt?: TableMetadataOptions): TableMetadata;
-    fetchTableMetadata(opt?: FetchTableMetadataOptions<Model>): Promise<TableMetadata>;
+    fetchTableMetadata(opt?: FetchTableMetadataOptions): Promise<TableMetadata>;
   }
 
   // TS 2.5 doesn't support interfaces with static methods or fields, so
@@ -502,7 +502,7 @@ declare namespace Objection {
     static traverse(models: Model | Model[], traverser: TraverserFunction): void;
 
     static tableMetadata(opt?: TableMetadataOptions): TableMetadata;
-    static fetchTableMetadata(opt?: FetchTableMetadataOptions<Model>): Promise<TableMetadata>;
+    static fetchTableMetadata(opt?: FetchTableMetadataOptions): Promise<TableMetadata>;
     // Implementation note: At least as of TypeScript 2.7, subclasses of
     // methods that return `this` are not compatible with their superclass.
     // For example, `class Movie extends Model` could not be passed as a

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -246,7 +246,6 @@ declare namespace Objection {
   }
 
   export interface FetchTableMetadataOptions {
-    parentBuilder?: QueryBuilder<Model>;
     knex?: knex;
     force?: boolean;
     table?: string;


### PR DESCRIPTION
I'm not super confident in these, especially `FetchTableMetadataOptions.parentBuilder`, but this attempts to add types for the new functions exposed in ff9af5d by @koskimas 