### PR TITLE
Adding beforeInsert to RelationMapping interface

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -204,6 +204,7 @@ declare namespace Objection {
     join: RelationJoin;
     modify?: (queryBuilder: QueryBuilder<any>) => QueryBuilder<any>;
     filter?: (queryBuilder: QueryBuilder<any>) => QueryBuilder<any>;
+    beforeInsert?: (queryContext: QueryContext) => Promise<any> | void;
   }
 
   export interface EagerAlgorithm {


### PR DESCRIPTION
Hi I noticed that the beforeInsert method defined in the documentation is missing from the typings file. This pull request will fix that.

Apologies for not creating an issue before sending the pull request. It was a blocker for me, so I needed to fix it for my own needs.