### PR TITLE
Missing applyFilter() and eagerOptions() from TypeScript typings

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -641,7 +641,7 @@ declare namespace Objection {
     modify(func: (builder: this) => void): this;
     modify(namedFilter: string): this;
 
-    applyFilter(...namedFilters: string): this;
+    applyFilter(...namedFilters: string[]): this;
 
     findById(id: Id): QueryBuilderYieldingOneOrNone<QM>;
     findById(idOrIds: IdOrIds): this;

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -641,6 +641,8 @@ declare namespace Objection {
     modify(func: (builder: this) => void): this;
     modify(namedFilter: string): this;
 
+    applyFilter(...namedFilters: string): this;
+
     findById(id: Id): QueryBuilderYieldingOneOrNone<QM>;
     findById(idOrIds: IdOrIds): this;
     findByIds(ids: Id[] | Id[][]): this;
@@ -778,6 +780,7 @@ declare namespace Objection {
     onError(fn: (error: Error, builder: this) => any): this;
 
     eagerAlgorithm(algo: EagerAlgorithm): this;
+    eagerOptions(opts: EagerOptions): this;
 
     eager(relationExpression: RelationExpression, filters?: FilterExpression<QM>): this;
     mergeEager(relationExpression: RelationExpression, filters?: FilterExpression<QM>): this;


### PR DESCRIPTION
https://github.com/Vincit/objection.js/issues/895

- add the two missing methods to TypeScript typings