### PR TITLE
feat(QueryBuilder): add timeout(ms, options?)

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -1287,6 +1287,19 @@ Type|Description
 
 
 
+#### timeout
+
+See [knex documentation](http://knexjs.org/#Builder-timeout)
+
+##### Return value
+
+Type|Description
+----|-----------------------------
+[`QueryBuilder`](#querybuilder)|`this` query builder for chaining.
+
+
+
+
 #### as
 
 See [knex documentation](http://knexjs.org/#Builder-as)

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -442,6 +442,10 @@ class QueryBuilder extends QueryBuilderBase {
     return this.toString();
   }
 
+  timeout(ms, options) {
+    return this.build().timeout(ms, options);
+  }
+
   clone() {
     const builder = new this.constructor(this._modelClass);
 

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -442,8 +442,8 @@ class QueryBuilder extends QueryBuilderBase {
     return this.toString();
   }
 
-  timeout(ms, options) {
-    return this.build().timeout(ms, options);
+  static query(trx) {
+    return this.QueryBuilder.forClass(this).transacting(trx);
   }
 
   clone() {
@@ -1084,6 +1084,10 @@ class QueryBuilder extends QueryBuilderBase {
 
   table() {
     return this.addOperation(new FromOperation('table'), arguments);
+  }
+
+  timeout() {
+    return this.addOperation(new KnexOperation('timeout'), arguments);
   }
 }
 

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -442,10 +442,6 @@ class QueryBuilder extends QueryBuilderBase {
     return this.toString();
   }
 
-  static query(trx) {
-    return this.QueryBuilder.forClass(this).transacting(trx);
-  }
-
   clone() {
     const builder = new this.constructor(this._modelClass);
 
@@ -1084,10 +1080,6 @@ class QueryBuilder extends QueryBuilderBase {
 
   table() {
     return this.addOperation(new FromOperation('table'), arguments);
-  }
-
-  timeout() {
-    return this.addOperation(new KnexOperation('timeout'), arguments);
   }
 }
 

--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -659,6 +659,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
   orWhereJsonIsObject(fieldExpression) {
     return this.orWhereJsonSupersetOf(fieldExpression, {});
   }
+
+  timeout() {
+    return this.addOperation(new KnexOperation('timeout'), arguments);
+  }
 }
 
 Object.defineProperties(QueryBuilderBase.prototype, {

--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -266,6 +266,13 @@ describe('QueryBuilder', () => {
       });
   });
 
+  it('should return a QueryBuilder from .timeout method', () => {
+    const builder = QueryBuilder.forClass(TestModel).timeout(3000);
+
+    expect(builder).to.be.a(QueryBuilder);
+    return builder;
+  });
+
   describe('where(..., ref(...))', () => {
     it('should create a where clause using column references instead of values (1)', () => {
       return QueryBuilder.forClass(TestModel)

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -814,8 +814,6 @@ declare namespace Objection {
 
     clone(): this;
 
-    timeout(ms: number, options?: TimeoutOptions): this;
-
     // We get `then` and `catch` by extending Promise
 
     map<V, Result>(mapper: BluebirdMapper<V, Result>): Promise<Result[]>;
@@ -847,6 +845,8 @@ declare namespace Objection {
     omit(properties: string[]): this;
 
     returning(columns: string | string[]): QueryBuilder<QM, RM>;
+
+    timeout(ms: number, options: TimeoutOptions): this;
   }
 
   export interface transaction<T> {

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -345,6 +345,10 @@ declare namespace Objection {
     [propertyName: string]: boolean;
   }
 
+  interface TimeoutOptions {
+    cancel: boolean;
+  }
+
   /**
    * ModelClass is a TypeScript hack to support referencing a Model
    * subclass constructor and not losing access to static members. See
@@ -809,6 +813,8 @@ declare namespace Objection {
     transacting(transation: Transaction): this;
 
     clone(): this;
+
+    timeout(ms: number, options?: TimeoutOptions): this;
 
     // We get `then` and `catch` by extending Promise
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -846,7 +846,7 @@ declare namespace Objection {
 
     returning(columns: string | string[]): QueryBuilder<QM, RM>;
 
-    timeout(ms: number, options: TimeoutOptions): this;
+    timeout(ms: number, options?: TimeoutOptions): this;
   }
 
   export interface transaction<T> {


### PR DESCRIPTION
This PR adds the function timeout(ms, options?) to the QueryBuilder. It's possible to set timeouts for specific queries. 

The timeout feature was first implemented in Knex on Feb 15, 2016 (https://github.com/tgriesser/knex/commit/6dfe653c42002e706504d8f56285cf5b500ff4e2#diff-2ee33e306d47d27f6349fbefe16e28e0).

This PR is related to the issue #905