### PR TITLE
Add composite id typing for patchAndFetchById

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -676,7 +676,7 @@ declare namespace Objection {
      * @return a Promise of the number of patched rows
      */
     patch(modelOrObject: Partial<QM>): QueryBuilderYieldingCount<QM, RM>;
-    patchAndFetchById(id: Id, modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
+    patchAndFetchById(idOrIds: IdOrIds, modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
     patchAndFetch(modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
 
     upsertGraph: Upsert<QM>;


### PR DESCRIPTION
As stated in the [documentation](http://vincit.github.io/objection.js/#composite-keys) and visible in the code, `patchAndFetchById` supports finds with composite ids. However, currently the TypeScript typings only indicate that single column ids are supported.

This PR updates the typings to be in line with the implementation and documentation.