### PR TITLE
Overview for API#models and tabbed-example component

### DIFF
--- a/newDoc/.vuepress/components/tab.vue
+++ b/newDoc/.vuepress/components/tab.vue
@@ -1,0 +1,39 @@
+<template>
+  <section v-show="isActive"
+       :aria-hidden="!isActive"
+       class="tabs-component-panel"
+       :id="hash"
+       role="tabpanel"
+  >
+    <slot />
+  </section>
+</template>
+
+<script>
+  export default {
+    props: {
+      id: { default: null },
+      name: { required: true },
+      prefix: { default: '' },
+      suffix: { default: '' },
+      isDisabled:{ default: false },
+    },
+    data: () => ({
+      isActive: false,
+      isVisible: true,
+    }),
+    computed: {
+      header() {
+        return this.prefix + this.name + this.suffix;
+      },
+      hash() {
+        if (this.isDisabled) {
+          return '#';
+        }
+        return this.id ?
+          '#' + this.id :
+          '#' + this.name.toLowerCase().replace(/ /g, '-');
+      },
+    },
+  };
+</script>

--- a/newDoc/.vuepress/components/tabbed-example.vue
+++ b/newDoc/.vuepress/components/tabbed-example.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="tabbed-example">
+    <ul role="tablist" class="tabbed-example-tabs">
+      <li
+        v-for="(tab, i) in tabs"
+        :key="i"
+        :class="{ 'is-active': tab.isActive, 'is-disabled': tab.isDisabled }"
+        class="tabbed-example-tab"
+        role="presentation"
+        v-show="tab.isVisible"
+      >
+        <a
+          v-html="tab.header"
+          :aria-controls="tab.hash"
+          :aria-selected="tab.isActive === activeTabHash"
+          @click="selectTab(tab.hash, $event)"
+          :href="tab.hash"
+          class="tabbed-example-tab-a"
+          role="tab"
+        ></a>
+      </li>
+    </ul>
+    <div class="tabbed-example-panels">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {},
+    data: () => ({
+      tabs: [],
+      activeTabHash: '',
+    }),
+    created() {
+      this.tabs = this.$children;
+    },
+    mounted() {
+      if (this.findTab(window.location.hash)) {
+        this.selectTab(window.location.hash);
+        return;
+      }
+
+      if (this.tabs.length) {
+        // if we want to change the default tab,
+        // this is where to do it
+        this.selectTab(this.tabs[0].hash);
+      }
+    },
+    methods: {
+      findTab(hash) {
+        return this.tabs.find(tab => tab.hash === hash);
+      },
+      selectTab(selectedTabHash, event) {
+        // See if we should store the hash in the url fragment.
+        if (event) {
+          event.preventDefault();
+        }
+        const selectedTab = this.findTab(selectedTabHash);
+        if (!selectedTab) {
+          return;
+        }
+        if (selectedTab.isDisabled) {
+          return;
+        }
+        this.tabs.forEach(tab => {
+          tab.isActive = (tab.hash === selectedTab.hash);
+        });
+
+        this.$emit('changed', { tab: selectedTab });
+        this.activeTabHash = selectedTab.hash;
+      },
+      setTabVisible(hash, visible) {
+        const tab = this.findTab(hash);
+        if (!tab) {
+          return;
+        }
+
+        tab.isVisible = visible;
+        if (tab.isActive) {
+          // If tab is active, set a different one as active.
+          tab.isActive = visible;
+          this.tabs.every((tab, index, array) => {
+            if (tab.isVisible) {
+              tab.isActive = true;
+              return false;
+            }
+            return true;
+          });
+        }
+      },
+    },
+  };
+</script>

--- a/newDoc/.vuepress/config.js
+++ b/newDoc/.vuepress/config.js
@@ -42,5 +42,65 @@ module.exports = {
         ]
       }]
     }
+  },
+  markdown: {
+    config: md => {
+      let id = 0;
+      let currentTitle = null;
+      let firstContent = true;
+      const regex = /multi-language (.*)/;
+      md.use(require('markdown-it-container'), 'multi-language', {
+        render(tokens, idx) {
+          let argString;
+
+          try {
+            const matched = tokens[idx].info.trim().match(regex);
+            argString = matched[1];
+          } catch (e) {
+            return tokens[idx].info.trim();
+          }
+
+          const args = argString.split(/\s+/);
+
+          switch (args[0]) {
+            case 'example': {
+              switch (args[1]) {
+                case 'begin': {
+                  return `<tabbed-example>`;
+                }
+                case 'end': {
+                  return `</tabbed-example>`;
+                }
+                default: {
+                  throw new Error(`Failed to parse line "${tokens[idx].info}"`);
+                }
+              }
+            }
+            case 'section': {
+              const tabTitle = args[1];
+              switch (args[2]) {
+                case 'begin': {
+                  return `<tab name="${tabTitle}">`;
+                }
+                case 'end': {
+                  return `
+                        </tab>
+                  `;
+                }
+                default: {
+                  throw new Error(`Failed to parse line "${tokens[idx].info}"`);
+                }
+              }
+            }
+          }
+
+          return `
+            <pre class="language-json">
+              ${JSON.stringify(args)}
+            </pre>
+          `;
+        }
+      });
+    }
   }
-}
+};

--- a/newDoc/.vuepress/override.styl
+++ b/newDoc/.vuepress/override.styl
@@ -1,0 +1,66 @@
+$backgroundColor = #ffffff;
+
+.tabbed-example
+    margin 1em 0
+
+.tabbed-example-tabs
+    border solid 1px $borderColor
+    border-radius 6px
+    margin-bottom 5px
+
+@media (min-width: 700px)
+    .tabbed-example-tabs
+        border 0
+        align-items stretch
+        display flex
+        justify-content flex-start
+        margin-bottom -1px
+
+.tabbed-example-tab
+    background-color darken($backgroundColor, 7)
+    color lighten($textColor, 30)
+    font-size 12px
+    font-weight 600
+    margin-right 0
+    list-style none
+    &:not(:last-child)
+        border-bottom solid 1px $backgroundColor
+    &:hover
+        color lighten($borderColor, 20)
+    &.is-active
+        background-color $backgroundColor
+        color $textColor
+    &.is-disabled
+        *
+            color darken($backgroundColor, 20)
+            cursor not-allowed !important
+
+@media (min-width: 700px)
+    .tabbed-example-tab
+        border solid 1px $borderColor
+        border-radius 3px 3px 0 0
+        margin-right .5em
+        transform translateY(2px)
+        transition transform .3s ease
+        &.is-active
+            border-bottom solid 1px $backgroundColor
+            z-index 2
+            transform translateY(0)
+
+.tabbed-example-tab-a
+    align-items center
+    color inherit
+    display flex
+    padding .5em .75em
+    text-decoration none
+
+.tabbed-example-panels
+    padding 1em 0
+
+@media (min-width: 700px)
+    .tabbed-example-panels
+        border-top-left-radius 0
+        border solid 1px $borderColor
+        border-radius 0 6px 6px 6px
+        box-shadow 0 0 10px rgba(0, 0, 0, .05)
+        padding 0 1em

--- a/newDoc/api/model.md
+++ b/newDoc/api/model.md
@@ -1,6 +1,35 @@
 # class Model
 
-## static tableName
+> Subclasses of this class represent database tables.
+
+## Overview
+
+#### Model Lifecycle
+
+For the purposes of this explanation, let’s define three data layouts:
+
+1. `database`: The data layout returned by the database.
+1. `internal`: The data layout of a model instance.
+1. `external`: The data layout after calling model.toJSON().
+
+Whenever data is converted from one layout to another, converter methods are called:
+
+1. `database` -> [`$parseDatabaseJson`](/TODO/$parseDatabsaeJson) -> `internal`
+1. `internal` -> [`$formatDatabaseJson`](/TODO/$formatDatabaseJson) -> `database`
+1. `external` -> [`$parseJson`](/TODO/$parseJson) -> `internal`
+1. `internal` -> [`$formatJson`](/TODO/$formatJson) -> `external`
+
+So for example when the results of a query are read from the database the data goes through the [`$parseDatabaseJson`](/TODO/$parseDatabaseJson) method. When data is written to database it goes through the [`$formatDatabaseJson`](/TODO/$formatDatabaseJson) method.
+
+Similarly when you give data for a query (for example [`query().insert(req.body))`](/TODO/insert) or create a model explicitly using [`Model.fromJson(obj)`](/TODO/fromjson) the [`$parseJson`](/TODO/$parseJson) method is invoked. When you call [`model.toJSON()`](/TODO/tojson) or [`model.$toJson()`](/TODO/tojson) the [`$formatJson`](/TODO/formatJson) is called.
+
+Note: Most libraries like [express](http://expressjs.com/en/index.html) automatically call the [`toJSON`](/TODO/tojson/) method when you pass the model to methods like `response.json(model)`. You rarely need to call [`toJSON()`](/TODO/tojson) or [`$toJson()`](/TODO/$tojson) explicitly.
+
+By overriding the lifecycle methods, you can have different layouts for the data in database and when exposed to the outside world. See [this recipe](/TODO/map-column-names-to-different-property-names) for an example usage of the lifecycle methods.
+
+All instance methods of models are prefixed with `$` letter so that they won’t overlap with database properties. All properties that start with `$` are also removed from `database` and `external` layouts.
+
+### static tableName
 
 <!-- The first simple example before the description -->
 ```js

--- a/newDoc/api/model.md
+++ b/newDoc/api/model.md
@@ -1,3 +1,4 @@
+
 # class Model
 
 > Subclasses of this class represent database tables.
@@ -29,9 +30,14 @@ By overriding the lifecycle methods, you can have different layouts for the data
 
 All instance methods of models are prefixed with `$` letter so that they won’t overlap with database properties. All properties that start with `$` are also removed from `database` and `external` layouts.
 
+## Static properties
+
 ### static tableName
 
 <!-- The first simple example before the description -->
+
+::: multi-language example begin
+::: multi-language section ES2015 begin
 ```js
 class Person extends Model {
   static get tableName() {
@@ -39,6 +45,16 @@ class Person extends Model {
   }
 }
 ```
+::: multi-language section ES2015 end
+::: multi-language section ESNext begin
+```js
+class Person extends Model {
+  static tableName = 'persons';
+}
+```
+::: multi-language section ESNext end
+::: multi-language example end
+
 
 Name of the database table for this model.
 
@@ -47,17 +63,140 @@ Each model must set this.
 <!-- Rest of the examples after under #### Examples header -->
 #### Examples
 
-Using ESNext static properties
+##### Using ESNext static properties
+
+
+### static jsonSchema
+
+
+::: multi-language example begin
+::: multi-language section ES2015 begin
 
 ```js
 class Person extends Model {
-  static tableName = 'persons';
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        id: {type: 'integer'},
+        name: {type: 'string', minLength: 1, maxLength: 255},
+        age: {type: 'number'}, // optional
+      }
+    };
+  }
+}
+```
+::: multi-language section ES2015 end
+::: multi-language section ESNext begin
+
+```js
+class Person extends Model {
+  static jsonSchema = {
+    type: 'object',
+    required: ['name'],
+    properties: {
+      id: {type: 'integer'},
+      name: {type: 'string', minLength: 1, maxLength: 255},
+      age: {type: 'number'}, // optional
+    }
+  }
+}
+```
+::: multi-language section ESNext end
+::: multi-language example end
+
+The optional schema against which the JSON is validated.
+
+The jsonSchema can be dynamically modified in the [`$beforeValidate`](/TODO/$beforevalidate) method.
+
+Must follow [JSON Schema](http://json-schema.org) specification. If null no validation is done.
+
+#### Read more
+
+* [`$beforeValidate`](/TODO/$beforevalidate)
+* [`$validate`](/TODO/$validate)
+* [`$afterValidate`](/TODO/$aftervalidate)
+* [`jsonAttributes`](/TODO/jsonattributes)
+* [custom validation recipe](/TODO/custom-validation)
+
+#### Examples
+
+##### Person
+
+::: multi-language example begin
+::: multi-language section ES2015 begin
+```js
+class Person extends Model {
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['firstName', 'lastName'],
+
+      properties: {
+        id: {type: 'integer'},
+        parentId: {type: ['integer', 'null']},
+        firstName: {type: 'string', minLength: 1, maxLength: 255},
+        lastName: {type: 'string', minLength: 1, maxLength: 255},
+        age: {type: 'number'},
+
+        // Properties defined as objects or arrays are
+        // automatically converted to JSON strings when
+        // writing to database and back to objects and arrays
+        // when reading from database. To override this
+        // behaviour, you can override the
+        // Person.jsonAttributes property.
+        address: {
+          type: 'object',
+          properties: {
+            street: {type: 'string'},
+            city: {type: 'string'},
+            zipCode: {type: 'string'}
+          }
+        }
+      }
+    };
+  }
+}
+```
+::: multi-language section ES2015 end
+::: multi-language section ESNext begin
+```js
+class Person extends Model {
+  static jsonSchema = {
+    type: 'object',
+    required: ['firstName', 'lastName'],
+
+    properties: {
+      id: {type: 'integer'},
+      parentId: {type: ['integer', 'null']},
+      firstName: {type: 'string', minLength: 1, maxLength: 255},
+      lastName: {type: 'string', minLength: 1, maxLength: 255},
+      age: {type: 'number'},
+
+      // Properties defined as objects or arrays are
+      // automatically converted to JSON strings when
+      // writing to database and back to objects and arrays
+      // when reading from database. To override this
+      // behaviour, you can override the
+      // Person.jsonAttributes property.
+      address: {
+        type: 'object',
+        properties: {
+          street: {type: 'string'},
+          city: {type: 'string'},
+          zipCode: {type: 'string'}
+        }
+      }
+    }
+  };
 }
 ```
 
-## static relationMappings
+::: multi-language section ESNext end
+::: multi-language example end
 
-## static jsonSchema
+## static relationMappings
 
 <!-- static properties like this -->
 ## static idColumn

--- a/package.json
+++ b/package.json
@@ -79,12 +79,14 @@
     "glob": "^7.1.2",
     "istanbul": "^0.4.5",
     "knex": "0.x",
+    "markdown-it-container": "^2.0.0",
     "mocha": "^5.0.0",
     "mysql": "^2.15.0",
     "pg": "^7.4.1",
     "prettier": "^1.10.2",
     "sqlite3": "^4.0.0",
     "typescript": "^2.7.1",
+    "vue-tabs-component": "^1.4.0",
     "vuepress": "^0.8.4"
   }
 }


### PR DESCRIPTION
I had to use a combination of vue components and a plugin for the
vuepress default theme. Vuepress's default config has the power to be
configured heavily, but it's a little weird. If I just used the vue
components in the md directly, it would take the children of the
components (which should be turned into codeblocks) and make that just
one text component, so it wouldn't get processed by markdown-it. But if
I used markdown-it-container, the HTML replacement occurs before
runtime.

It's possible using <ClientOnly> would have worked, but I didn't try.
This way feels more extensible, though slightly gross.