### PR TITLE
adds a missing method andWhereRaw

### DIFF
--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -216,6 +216,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     return this.addOperation(new KnexOperation('havingWrapped'), arguments);
   }
 
+  andWhereRaw() {
+    return this.addOperation(new KnexOperation('andWhereRaw'), arguments);
+  }
+  
   orWhereRaw() {
     return this.addOperation(new KnexOperation('orWhereRaw'), arguments);
   }


### PR DESCRIPTION
which objection.js is supposed to have according to it's typescript typings