### PR TITLE
Simple parameter type conversion when using page

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -681,7 +681,7 @@ class QueryBuilder extends QueryBuilderBase {
   }
 
   page(page, pageSize) {
-    return this.range(page * pageSize, (page + 1) * pageSize - 1);
+    return this.range(+page * +pageSize, (+page + 1) * +pageSize - 1);
   }
 
   columnInfo({ table = null } = {}) {


### PR DESCRIPTION
Hey!

I'm not sure if this is desirable, but I feel like pagination parameters often come from querystrings and maybe we should make sure those parameters are integer before doing calculations that will result in very strange results.

Thanks for Objection.js, it is a core module of my project and I love using it everyday.