### PR TITLE
Fix EagerOptions types

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -212,10 +212,20 @@ declare namespace Objection {
     // TODO should this be something other than a tagging interface?
   }
 
+  export type JoinOperation = 'join'
+    | 'innerJoin'
+    | 'outerJoin'
+    | 'leftJoin'
+    | 'leftOuterJoin'
+    | 'rightJoin'
+    | 'rightOuterJoin'
+    | 'fullOuterJoin'
+
   export interface EagerOptions {
     minimize?: boolean;
     separator?: string;
-    aliases?: string[];
+    aliases?: { [relation: string]: string }
+    joinOperation?: JoinOperation;
   }
 
   export interface UpsertOptions {


### PR DESCRIPTION
Make `EagerOptions` match the type definitions at: http://vincit.github.io/objection.js/#eageroptions

The `JoinOperation` enum is based on the operations found at: https://github.com/Vincit/objection.js/blob/a4158140ecd6728ea05fa2c02751f4c645681dd2/lib/queryBuilder/QueryBuilder.js#L962