### PR TITLE
support bindKnexRelations

### DIFF
--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -1,6 +1,6 @@
 const { clone } = require('./modelClone');
 const { asArray } = require('../utils/objectUtils');
-const { bindKnex } = require('./modelBindKnex');
+const { bindKnex, bindKnexRelations } = require('./modelBindKnex');
 const { validate } = require('./modelValidate');
 const { isPromise } = require('../utils/promiseUtils');
 const { omit, pick } = require('./modelFilter');
@@ -503,8 +503,12 @@ class Model {
     }
   }
 
-  static bindKnex(knex) {
-    return bindKnex(this, knex);
+  static bindKnex(knex, notAutoBindRelations) {
+    return bindKnex(this, knex, notAutoBindRelations);
+  }
+
+  static bindKnexRelations(knex) {
+    return bindKnexRelations(this, knex);
   }
 
   static bindTransaction(trx) {

--- a/lib/model/modelBindKnex.js
+++ b/lib/model/modelBindKnex.js
@@ -2,7 +2,13 @@ const { inheritModel } = require('./inheritModel');
 const { staticHiddenProps } = require('./modelUtils');
 const { defineNonEnumerableProperty } = require('./modelUtils');
 
-function bindKnex(modelClass, knex) {
+function bindKnexRelations(modelClass, knex) {
+  let BoundModelClass = getBoundModelFromCache(modelClass, knex);
+  BoundModelClass = bindRelations(modelClass, BoundModelClass, knex);
+  return BoundModelClass;
+}
+
+function bindKnex(modelClass, knex, notAutoBindRelations) {
   let BoundModelClass = getBoundModelFromCache(modelClass, knex);
 
   if (BoundModelClass === null) {
@@ -12,7 +18,9 @@ function bindKnex(modelClass, knex) {
     BoundModelClass.knex(knex);
 
     BoundModelClass = putBoundModelToCache(modelClass, BoundModelClass, knex);
-    BoundModelClass = bindRelations(modelClass, BoundModelClass, knex);
+    if (!notAutoBindRelations) {
+      BoundModelClass = bindRelations(modelClass, BoundModelClass, knex);
+    }
   }
 
   return BoundModelClass;
@@ -80,5 +88,6 @@ function bindRelations(modelClass, BoundModelClass, knex) {
 }
 
 module.exports = {
-  bindKnex
+  bindKnex,
+  bindKnexRelations
 };


### PR DESCRIPTION
A solutions to the require loops.

you can bindKnexRelations after bindKnex.

```
const models = {}
class Animal extends Model {
  static tableName = 'animals';

  static relationMappings = {
    owner: {
      relation: Model.BelongsToOneRelation,
      modelClass: models.Person,
      join: {
        from: 'animals.ownerId',
        to: 'persons.id'
      }
    }
  }
}
class Person extends Model {
  static tableName = 'persons';

  static relationMappings = {
    animals: {
      relation: Model.HasManyRelation,
      modelClass: models.Animal,
      join: {
        from: 'persons.id',
        to: 'animals.ownerId'
      }
    }
  }
}

models.Animal = Animal.bindKnex(knex, true)
models.Person = Person.bindKnex(knex, true)
Object.values(models).forEach(Model => {
  // get relationMappings after bindKnex
  Model.bindKnexRelations(knex)
})
```