### PR TITLE
TypeScript: Allow non-static values for 'patch' and 'update'

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -408,6 +408,20 @@ const rowsDeleted: Promise<number> = qb.delete();
 const rowsDeletedById: Promise<number> = qb.deleteById(123);
 const rowsDeletedByIds: Promise<number> = qb.deleteById([123, 456]);
 
+const rowsUpdatedWithData: Promise<number>[] = [
+  qb.update({firstName: "name"}),
+  qb.update({firstName: ref('last_name') }),
+  qb.update({firstName: raw('"name"')}),
+  qb.update({firstName: qb.select('lastname')})
+];
+
+const rowsPatchedWithData: Promise<number>[] = [
+  qb.patch({firstName: "name"}),
+  qb.patch({firstName: ref('last_name') }),
+  qb.patch({firstName: raw('"name"')}),
+  qb.patch({firstName: qb.select('lastname')})
+];
+
 const insertedModel: Promise<Person> = Person.query().insertAndFetch({});
 const insertedModels1: Promise<Person[]> = Person.query().insertGraphAndFetch([
   new Person(),
@@ -439,6 +453,30 @@ const updatedModel: Promise<Person> = Person.query().updateAndFetch({});
 const updatedModelById: Promise<Person> = Person.query().updateAndFetchById(123, {});
 const patchedModel: Promise<Person> = Person.query().patchAndFetch({});
 const patchedModelById: Promise<Person> = Person.query().patchAndFetchById(123, {});
+
+const updatedModels: Promise<Person>[] = [
+  qb.updateAndFetch({firstName: "name"}),
+  qb.updateAndFetch({firstName: ref('last_name') }),
+  qb.updateAndFetch({firstName: raw('"name"')}),
+  qb.updateAndFetch({firstName: qb.select('lastname')}),
+
+  qb.updateAndFetchById(123, {firstName: "name"}),
+  qb.updateAndFetchById(123, {firstName: ref('last_name') }),
+  qb.updateAndFetchById(123, {firstName: raw('"name"')}),
+  qb.updateAndFetchById(123, {firstName: qb.select('lastname')})
+];
+
+const patchedModels: Promise<Person>[] = [
+  qb.patchAndFetch({firstName: "name"}),
+  qb.patchAndFetch({firstName: ref('last_name') }),
+  qb.patchAndFetch({firstName: raw('"name"')}),
+  qb.patchAndFetch({firstName: qb.select('lastname')}),
+
+  qb.patchAndFetchById(123, {firstName: "name"}),
+  qb.patchAndFetchById(123, {firstName: ref('last_name') }),
+  qb.patchAndFetchById(123, {firstName: raw('"name"')}),
+  qb.patchAndFetchById(123, {firstName: qb.select('lastname')})
+];
 
 const rowsEager: Promise<Person[]> = Person.query()
   .eagerAlgorithm(Person.NaiveEagerAlgorithm)

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -657,6 +657,10 @@ declare namespace Objection {
     (modelsOrObjects?: Partial<QM>[], options?: InsertGraphOptions): QueryBuilder<QM, QM[]>;
   }
 
+  type PartialUpdate<QM extends Model> = {
+    [P in keyof QM]?: QM[P] | Raw | Reference | QueryBuilder<any, any[]>
+  }
+
   interface QueryBuilderBase<QM extends Model, RM, RV> extends QueryInterface<QM, RM, RV> {
     modify(func: (builder: this) => void): this;
     modify(namedFilter: string): this;
@@ -685,16 +689,16 @@ declare namespace Objection {
     /**
      * @return a Promise of the number of updated rows
      */
-    update(modelOrObject: Partial<QM>): QueryBuilderYieldingCount<QM, RM>;
-    updateAndFetch(modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
-    updateAndFetchById(id: Id, modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
+    update(modelOrObject: PartialUpdate<QM>): QueryBuilderYieldingCount<QM, RM>;
+    updateAndFetch(modelOrObject: PartialUpdate<QM>): QueryBuilder<QM, QM>;
+    updateAndFetchById(id: Id, modelOrObject: PartialUpdate<QM>): QueryBuilder<QM, QM>;
 
     /**
      * @return a Promise of the number of patched rows
      */
-    patch(modelOrObject: Partial<QM>): QueryBuilderYieldingCount<QM, RM>;
-    patchAndFetchById(idOrIds: IdOrIds, modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
-    patchAndFetch(modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
+    patch(modelOrObject: PartialUpdate<QM>): QueryBuilderYieldingCount<QM, RM>;
+    patchAndFetchById(idOrIds: IdOrIds, modelOrObject: PartialUpdate<QM>): QueryBuilder<QM, QM>;
+    patchAndFetch(modelOrObject: PartialUpdate<QM>): QueryBuilder<QM, QM>;
 
     upsertGraph: Upsert<QM>;
     upsertGraphAndFetch: Upsert<QM>;


### PR DESCRIPTION
The following dynamic values are now allowed to be passed as column
values to `patch` and `update`:

- Knex.Raw
- Reference
- QueryBuilder

Fixes #1036.