### PR TITLE
fixed typings for insertGraphAndFetch method

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -653,8 +653,8 @@ declare namespace Objection {
   }
 
   interface InsertGraphAndFetch<QM extends Model> {
-    (modelsOrObjects?: Partial<QM>, options?: InsertGraphOptions): QueryBuilder<QM, QM>;
     (modelsOrObjects?: Partial<QM>[], options?: InsertGraphOptions): QueryBuilder<QM, QM[]>;
+    (modelOrObject?: Partial<QM>, options?: InsertGraphOptions): QueryBuilder<QM, QM>;
   }
 
   type PartialUpdate<QM extends Model> = {


### PR DESCRIPTION
It was inconsistent with other method typings, and TypeScript was complaining that insertGraphAndFetch should only accept Array of Models/Objects.