### PR TITLE
Use up-to-date nyc instead of deprecated istanbul

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,5 +1,0 @@
-instrumentation:
-  excludes: ['lib/queryBuilder/parsers/jsonFieldExpressionParser.js', 'lib/queryBuilder/parsers/relationExpressionParser.js', 'testUtils/*', 'lib/utils/clone.js']
-
-reporting:
-  dir: ./testCoverage

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "lib/utils/clone.js"
     ],
     "reporter": [
-      "text"
+      "text-lcov"
     ],
     "report-dir": "./testCoverage"
   }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
       "lib/utils/clone.js"
     ],
     "reporter": [
-      "text-lcov"
+      "lcov",
+      "text"
     ],
     "report-dir": "./testCoverage"
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run eslint && mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --exclude \"tests/unit/relations/files/**\"",
-    "test-travis": "npm run eslint && istanbul --config=.istanbul.yml cover _mocha -- --slow 100 --timeout 60000 --reporter spec --recursive tests --exclude \"tests/unit/relations/files/**\" && npm run test-typings",
+    "test-travis": "npm run eslint && nyc mocha --slow 100 --timeout 60000 --reporter spec --recursive tests --exclude \"tests/unit/relations/files/**\" && npm run test-typings",
     "test-fast": "mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --bail --exclude \"tests/unit/relations/files/**\"",
     "test-opt": "mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --bail --trace_opt --trace_deopt --exclude \"tests/unit/relations/files/**\"",
     "test-prof": "mocha --slow 10 --timeout 15000 --reporter spec --recursive tests --prof --exclude \"tests/unit/relations/files/**\"",
@@ -76,13 +76,26 @@
     "expect.js": "^0.3.1",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
-    "istanbul": "^0.4.5",
     "knex": "0.x",
     "mocha": "^5.2.0",
     "mysql": "^2.15.0",
+    "nyc": "^13.0.1",
     "pg": "^7.4.1",
     "prettier": "1.13.6",
     "sqlite3": "^4.0.0",
     "typescript": "^2.7.1"
+  },
+  "nyc": {
+    "description": "test coverage",
+    "exclude": [
+      "lib/queryBuilder/parsers/jsonFieldExpressionParser.js",
+      "lib/queryBuilder/parsers/relationExpressionParser.js",
+      "testUtils/*",
+      "lib/utils/clone.js"
+    ],
+    "reporter": [
+      "text"
+    ],
+    "report-dir": "./testCoverage"
   }
 }


### PR DESCRIPTION
https://github.com/gotwarlost/istanbul is pretty much dead, all the active development is happening in https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-lib-coverage and nyc is the most convenient way to consume it.