### PR TITLE
Add test for propertyNameToColumnName

### DIFF
--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -1151,12 +1151,26 @@ describe('Model', () => {
           return _.mapKeys(json, (value, key) => {
             return _.snakeCase(key);
           });
+        },
+        jsonSchema: {
+          properties: {
+            someProperty: { type: 'string' }
+          }
         }
       });
     });
 
     it('should convert a property name to column name', () => {
       expect(Model1.propertyNameToColumnName('someProperty')).to.equal('some_property');
+    });
+
+    it('should return null if column name does not exist', () => {
+      Model1.pickJsonSchemaProperties = true;
+      expect(Model1.propertyNameToColumnName('otherProperty')).to.equal(null);
+    });
+
+    it('should return mapped property name if pickJsonSchemaProperties is true', () => {
+      expect(Model1.propertyNameToColumnName('otherProperty')).to.equal('other_property');
     });
   });
 


### PR DESCRIPTION
While building a Proxy that traps set calls for properties that don't exist as column names, I encountered a strange thing.

If you call `propertyNameToColumnName` for a property/column that does not exist in the database, null is not returned unless `pickJsonSchemaProperties` is set to true. I've added a test for the `null` return case, which didn't exist before.

Is this the intended behaviour? I would intuitively expect `propertyNameToColumnName` to return null if the column does not exist, regardless of other settings.

I noticed that `columnNameToPropertyName` does not work in the same way, i.e. it does not take `pickJsonSchemaProperties` into account. Should it do so? I'm happy to explore fixing that.