### PR TITLE
proposal: Convert Model.fn to a getter.

### DIFF
--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -502,9 +502,19 @@ class Model {
     return raw.apply(undefined, arguments).toKnexRaw(this);
   }
 
-  static fn() {
-    const knex = this.knex();
-    return knex.fn;
+  /**
+   * NB. for v2.0, this can simply return `this.knex().fn`.
+   * However, in order to maintain backwards comparability of a bug that didn't
+   * have this method as a setter, the returned value needs to be callable and
+   * return the "same" `knex#FunctionHelper` instance.
+   * The effect is that `Model.fn.now()` and `Model.fn().now()` produce the same result.
+   */
+  static get fn() {
+    const fnHelper = this.knex().fn;
+    const wrapper = () => fnHelper;
+    Object.assign(wrapper, fnHelper);
+    Object.setPrototypeOf(wrapper, Object.getPrototypeOf(fnHelper));
+    return wrapper;
   }
 
   static knexQuery() {

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -2178,6 +2178,20 @@ describe('Model', () => {
     expect(Model1.fn()).to.eql({ a: 1 });
   });
 
+  it('fn should be a shortcut to knex.fn', () => {
+    const Model1 = modelClass('Model1');
+    Model1.knex({ fn: { a: 1 } });
+    expect(Model1.fn.a).to.equal(1);
+
+    const Model2 = modelClass('Model2');
+    Model2.knex(knex({ client: 'pg' }));
+
+    const expected = Model2.knex()
+      .fn.now()
+      .toString();
+    expect(Model2.fn.now().toString()).to.equal(expected);
+  });
+
   it('make sure JSON.stringify works with toJSON (#869)', () => {
     class Person extends Model {
       static get idColumn() {


### PR DESCRIPTION
Relates to #1115;

Turning `fn` into a getter better reflects the intention of shortcutting
to `knex.fn`, however, would be a breaking change if made alone.

This proposed patch converts it to a getter, but the returned
`knex#FunctionHelper` instance is callable and returns itself.
The effect is that `Model.fn.now()`, `Model.fn().now()`, and
`Model.knex().fn.now()` all produce the same result.