### PR TITLE
Improve error message thrown for unknown modifiers

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -357,9 +357,7 @@ function parseModify(ctx) {
       });
     } catch (err) {
       if (err instanceof ModifierNotFoundError) {
-        throw ctx.createError(
-          `Unable to determine modify function from provided value: "${modifier}".`
-        );
+        throw ctx.createError(err.message);
       } else {
         throw err;
       }

--- a/lib/utils/createModifier.js
+++ b/lib/utils/createModifier.js
@@ -2,7 +2,7 @@ const { asArray, isString, isFunction, isPlainObject } = require('./objectUtils'
 
 class ModifierNotFoundError extends Error {
   constructor(mofifierName) {
-    super();
+    super(`Unable to determine modify function from provided value: "${mofifierName}".`);
     this.mofifierName = mofifierName;
   }
 }
@@ -17,9 +17,11 @@ function createModifier({ modelClass, modifier, modifiers, args }) {
     let modify = null;
 
     if (isString(modifier)) {
-      modifier = modifiers[modifier] || modelModifiers[modifier];
+      modify = modifiers[modifier] || modelModifiers[modifier];
       // Modifiers can be pointers to other modifiers. Call this function recursively.
-      return createModifier({ modelClass, modifier, modifiers });
+      if (modify) {
+        return createModifier({ modelClass, modifier: modify, modifiers });
+      }
     } else if (isFunction(modifier)) {
       modify = modifier;
     } else if (isPlainObject(modifier)) {

--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -116,6 +116,20 @@ describe('QueryBuilder', () => {
     expect(called).to.equal(true);
   });
 
+  it('should throw if an unknown modifier is specified', () => {
+    const builder = QueryBuilder.forClass(TestModel);
+
+    TestModel.modifiers = {};
+
+    expect(() => {
+      builder.applyModifier('unknown');
+    }).to.throwException(err => {
+      expect(err.message).to.equal(
+        'Unable to determine modify function from provided value: "unknown".'
+      );
+    });
+  });
+
   ['applyFilter', 'applyModifier', 'modify'].forEach(method => {
     it(method + ' accept a list of strings and call the corresponding modifiers', () => {
       const builder = QueryBuilder.forClass(TestModel);


### PR DESCRIPTION
This PR addressed the problem in #1121

When calling `applyModifier('unkown')` on a query builder, a seemingly internal ` ModifierNotFoundError` is thrown without any error message set on it.

This change gives that error a human readable message.