### PR TITLE
Implement modifierNotFound() catch-all hook

### DIFF
--- a/doc/includes/API.md
+++ b/doc/includes/API.md
@@ -2418,7 +2418,7 @@ Type|Description
 
 
 
-#### applyFilter
+#### applyModifier
 
 Applies modifiers to the query builder.
 
@@ -2434,6 +2434,13 @@ modifier|string|The name of the modifier, as found in [`modifiers`](#modifiers).
 Type|Description
 ----|-----------------------------
 [`QueryBuilder`](#querybuilder)|`this` query builder for chaining.
+
+
+
+
+#### applyFilter
+
+An alias for [`applyModifier`](#applymodifier)
 
 
 
@@ -6182,6 +6189,40 @@ row|Object|A database row.
 Type|Description
 ----|-----------------------------
 [`Model`](#model)|The created model instance
+
+
+
+
+#### modifierNotFound
+
+```js
+class BaseModel extends Model {
+  static modifierNotFound(builder, modifier) {
+    const { properties } = this.jsonSchema
+    if (properties && modifier in properties) {
+      builder.select(modifier)
+    } else {
+      super.modifierNotFound(builder, modifier)
+    }
+  }
+}
+```
+
+Handles modifiers that are not recognized by the various mechanisms that can specify
+them, such as [`modify`](#modify) and [`applyModifier`](#applymodifier), as well as
+the use of modifiers in eager expressions (see [`RelationExpression`](#relationexpression))
+and in relations (see [`RelationMapping`](#relationmapping).
+
+By default, the static `modifierNotFound()` hook throws a `ModifierNotFoundError` error.
+If a model class overrides the hook, it can decide to handle the modifer through the passed
+`builder` instance, or call the hook's definition in the super class to still throw the error.
+
+##### Arguments
+
+Argument|Type|Description
+--------|----|-------------------
+builder|[`QueryBuilder`](#querybuilder)|The query builder on which to apply the modifier.
+modifier|string|The name of the unknown modifier.
 
 
 

--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -24,6 +24,7 @@ const AjvValidator = require('./AjvValidator');
 const QueryBuilder = require('../queryBuilder/QueryBuilder');
 const NotFoundError = require('./NotFoundError');
 const ValidationError = require('./ValidationError');
+const ModifierNotFoundError = require('./ModifierNotFoundError');
 const RelationProperty = require('../relations/RelationProperty');
 
 const HasOneRelation = require('../relations/hasOne/HasOneRelation');
@@ -337,6 +338,10 @@ class Model {
     });
   }
 
+  static modifierNotFound(builder, modifier) {
+    throw new this.ModifierNotFoundError(modifier);
+  }
+
   static createNotFoundError() {
     return new this.NotFoundError();
   }
@@ -644,6 +649,7 @@ Model.WhereInEagerAlgorithm = WhereInEagerAlgorithm;
 
 Model.ValidationError = ValidationError;
 Model.NotFoundError = NotFoundError;
+Model.ModifierNotFoundError = ModifierNotFoundError;
 
 Model.tableName = null;
 Model.jsonSchema = null;

--- a/lib/model/ModifierNotFoundError.js
+++ b/lib/model/ModifierNotFoundError.js
@@ -1,0 +1,8 @@
+class ModifierNotFoundError extends Error {
+  constructor(modifierName) {
+    super(`Unable to determine modify function from provided value: "${modifierName}".`);
+    this.modifierName = modifierName;
+  }
+}
+
+module.exports = ModifierNotFoundError;

--- a/lib/queryBuilder/operations/eager/RelationJoinBuilder.js
+++ b/lib/queryBuilder/operations/eager/RelationJoinBuilder.js
@@ -3,7 +3,7 @@ const Selection = require('../select/Selection');
 
 const { uniqBy, values } = require('../../../utils/objectUtils');
 const { Type: ValidationErrorType } = require('../../../model/ValidationError');
-const { createModifier, ModifierNotFoundError } = require('../../../utils/createModifier');
+const { createModifier } = require('../../../utils/createModifier');
 
 const ID_LENGTH_LIMIT = 63;
 const RELATION_RECURSION_LIMIT = 64;
@@ -575,16 +575,16 @@ function createModifierQuery({ builder, modelClass, expr, modifiers, relation })
 
   for (let i = 0, l = expr.$modify.length; i < l; ++i) {
     const modifierName = expr.$modify[i];
-    let modifier = null;
+    const modifier = createModifier({
+      modifier: modifierName,
+      modelClass: relation.relatedModelClass,
+      modifiers
+    });
 
     try {
-      modifier = createModifier({
-        modifier: modifierName,
-        modelClass: relation.relatedModelClass,
-        modifiers
-      });
+      modifier(modifierQuery);
     } catch (err) {
-      if (err instanceof ModifierNotFoundError) {
+      if (err instanceof modelClass.ModifierNotFoundError) {
         throw modelClass.createValidationError({
           type: ValidationErrorType.RelationExpression,
           message: `could not find modifier "${modifierName}" for relation "${relation.name}"`
@@ -593,8 +593,6 @@ function createModifierQuery({ builder, modelClass, expr, modifiers, relation })
         throw err;
       }
     }
-
-    modifier(modifierQuery);
   }
 
   return modifierQuery;

--- a/lib/queryBuilder/operations/eager/WhereInEagerOperation.js
+++ b/lib/queryBuilder/operations/eager/WhereInEagerOperation.js
@@ -4,7 +4,7 @@ const EagerOperation = require('./EagerOperation');
 const { isMsSql } = require('../../../utils/knexUtils');
 const { asArray, flatten, chunk } = require('../../../utils/objectUtils');
 const { Type: ValidationErrorType } = require('../../../model/ValidationError');
-const { createModifier, ModifierNotFoundError } = require('../../../utils/createModifier');
+const { createModifier } = require('../../../utils/createModifier');
 
 const RelationDoesNotExistError = require('../../../model/RelationDoesNotExistError');
 
@@ -145,18 +145,17 @@ class WhereInEagerOperation extends EagerOperation {
 
     for (let i = 0, l = expr.$modify.length; i < l; ++i) {
       const modifierName = expr.$modify[i];
-      let modifier = null;
+      const modifier = createModifier({
+        modifier: modifierName,
+        modelClass: relation.relatedModelClass,
+        modifiers: this.modifiers
+      });
 
       try {
-        modifier = createModifier({
-          modifier: modifierName,
-          modelClass: relation.relatedModelClass,
-          modifiers: this.modifiers
-        });
+        modifier(queryBuilder);
       } catch (err) {
-        if (err instanceof ModifierNotFoundError) {
-          const modelClass = builder.modelClass();
-
+        const modelClass = builder.modelClass();
+        if (err instanceof modelClass.ModifierNotFoundError) {
           throw modelClass.createValidationError({
             type: ValidationErrorType.RelationExpression,
             message: `could not find modifier "${modifierName}" for relation "${relation.name}"`
@@ -165,8 +164,6 @@ class WhereInEagerOperation extends EagerOperation {
           throw err;
         }
       }
-
-      modifier(queryBuilder);
     }
 
     return queryBuilder;

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -11,7 +11,7 @@ const { isSubclassOf } = require('../utils/classUtils');
 const { resolveModel } = require('../utils/resolveModel');
 const { get, isFunction } = require('../utils/objectUtils');
 const { mapAfterAllReturn } = require('../utils/promiseUtils');
-const { createModifier, ModifierNotFoundError } = require('../utils/createModifier');
+const { createModifier } = require('../utils/createModifier');
 
 class Relation {
   constructor(relationName, OwnerClass) {
@@ -128,7 +128,15 @@ class Relation {
       builder.resolve([]);
     }
 
-    return builder.modify(this.modify);
+    try {
+      return builder.modify(this.modify);
+    } catch (err) {
+      if (err instanceof this.relatedModelClass.ModifierNotFoundError) {
+        throw this.createError(err.message);
+      } else {
+        throw err;
+      }
+    }
   }
 
   join(
@@ -347,24 +355,12 @@ function createRelationProperty(ctx, refString, propName) {
 function parseModify(ctx) {
   const mapping = ctx.mapping;
   const modifier = mapping.modify || mapping.filter;
-  let modify;
-
-  if (modifier) {
-    try {
-      modify = createModifier({
-        modifier,
-        modelClass: ctx.relatedModelClass
-      });
-    } catch (err) {
-      if (err instanceof ModifierNotFoundError) {
-        throw ctx.createError(err.message);
-      } else {
-        throw err;
-      }
-    }
-  } else {
-    modify = () => {};
-  }
+  const modify =
+    modifier &&
+    createModifier({
+      modifier,
+      modelClass: ctx.relatedModelClass
+    });
 
   return Object.assign(ctx, { modify });
 }

--- a/lib/utils/createModifier.js
+++ b/lib/utils/createModifier.js
@@ -1,12 +1,5 @@
 const { asArray, isString, isFunction, isPlainObject } = require('./objectUtils');
 
-class ModifierNotFoundError extends Error {
-  constructor(mofifierName) {
-    super(`Unable to determine modify function from provided value: "${mofifierName}".`);
-    this.mofifierName = mofifierName;
-  }
-}
-
 function createModifier({ modelClass, modifier, modifiers, args }) {
   modifiers = modifiers || {};
   args = args || [];
@@ -31,7 +24,7 @@ function createModifier({ modelClass, modifier, modifiers, args }) {
     }
 
     if (!modify) {
-      throw new ModifierNotFoundError(modifier);
+      modify = builder => modelClass.modifierNotFound(builder, modifier);
     }
 
     return modify;
@@ -41,6 +34,5 @@ function createModifier({ modelClass, modifier, modifiers, args }) {
 }
 
 module.exports = {
-  createModifier,
-  ModifierNotFoundError
+  createModifier
 };


### PR DESCRIPTION
This PR relates to #1120 

It adds a way for a model class to provide a catch-all modifier for the case when a requested modifier isn't defined / found.

~~It is still work in progress, as its tests depend on #1122 to be merged, and docs still need to be written once we agree on the API surface.~~

```js
class MyModel extends Model {
  ...

  static modifierNotFound(builder, modifier) {
    // Do something with the modifier and the query, and return `true` if it was
    // handled, falsy otherwise, indicating Objection should still throw an error.
    const { properties } = this.getJsonSchema()
    if (properties && modifier in properties) {
      builder.select(modifier)
      return true
    }
  }
}
```

