### PR TITLE
Suppresses the warning of a dependency based on an expression

### DIFF
--- a/lib/utils/resolveModel.js
+++ b/lib/utils/resolveModel.js
@@ -54,7 +54,7 @@ function requireUsingModelPaths(modelRef, modelPaths) {
 function requireModel(modelPath) {
   const Model = getModel();
 
-  let mod = require(path.resolve(modelPath));
+  let mod = require(`${path.resolve(modelPath)}`);
   let modelClass = null;
 
   if (isSubclassOf(mod, Model)) {

--- a/lib/utils/resolveModel.js
+++ b/lib/utils/resolveModel.js
@@ -53,7 +53,12 @@ function requireUsingModelPaths(modelRef, modelPaths) {
 
 function requireModel(modelPath) {
   const Model = getModel();
-
+  /**
+   * Wrap path string in template literal to prevent
+   * warnings about Objection.JS being an expression
+   * in webpack builds.
+   * @link https://github.com/webpack/webpack/issues/196
+   */
   let mod = require(`${path.resolve(modelPath)}`);
   let modelClass = null;
 


### PR DESCRIPTION
Related to https://github.com/webpack/webpack/issues/196.

As implemented in other projects like so: https://github.com/zeit/now-cli/pull/1588/files

It's a simple fix to prevent the following dependency warning in certain webpack configurations.

```
WARNING in /Users/joel/Sites/asd/node_modules/objection/lib/utils/resolveModel.js 57:12-44
Critical dependency: the request of a dependency is an expression
    at CommonJsRequireContextDependency.getWarnings (/Users/joel/Sites/asd/node_modules/webpack/lib/dependencies/ContextDependency.js:40:18)
    at Compilation.reportDependencyErrorsAndWarnings (/Users/joel/Sites/asd/node_modules/webpack/lib/Compilation.js:1327:24)
    at Compilation.finish (/Users/joel/Sites/asd/node_modules/webpack/lib/Compilation.js:1138:9)
    at hooks.make.callAsync.err (/Users/joel/Sites/asd/node_modules/webpack/lib/Compiler.js:539:17)
    at _err0 (eval at create (/Users/joel/Sites/asd/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:11:1)
    at _addModuleChain (/Users/joel/Sites/asd/node_modules/webpack/lib/Compilation.js:1066:12)
    at processModuleDependencies.err (/Users/joel/Sites/asd/node_modules/webpack/lib/Compilation.js:982:9)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```