### PR TITLE
Disable optional increment and decrement amount

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1080,8 +1080,8 @@ declare namespace Objection {
     sumDistinct(columnName: string): this;
     avg(columnName: string): this;
     avgDistinct(columnName: string): this;
-    increment(columnName: string, amount?: number): this;
-    decrement(columnName: string, amount?: number): this;
+    increment(columnName: string, amount: number): this;
+    decrement(columnName: string, amount: number): this;
 
     debug(enabled?: boolean): this;
     pluck(column: string): this;


### PR DESCRIPTION
When I use `increment` function, I set amount as undefined, then error occur likes below.
```
Error: Undefined binding(s) detected when compiling RAW query: `abc` + ?
(abc is my column name)
```

So, I think the function `increment(columnName: string, amount?: number)` should be `increment(columnName: string, amount: number)`, update amount from optional to normal.