### PR TITLE
fixes count() method typings

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1113,7 +1113,7 @@ declare namespace Objection {
     limit(limit: number): this;
 
     // Aggregation
-    count(columnName?: string): this;
+    count: ColumnNamesMethod<QM, RM, RV>;
     countDistinct(columnName?: string): this;
     min(columnName: string): this;
     max(columnName: string): this;


### PR DESCRIPTION
count() accepts multiple arguments, not just a single one