### PR TITLE
adds a thunk type to RelationMapping.modelClass

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -223,7 +223,7 @@ declare namespace Objection {
 
   export interface RelationMapping {
     relation: Relation;
-    modelClass: ModelClass<any> | string;
+    modelClass: (() => ModelClass<any>) | ModelClass<any> | string;
     join: RelationJoin;
     modify?: ((queryBuilder: QueryBuilder<any>) => QueryBuilder<any>) | string | object;
     filter?: ((queryBuilder: QueryBuilder<any>) => QueryBuilder<any>) | string | object;


### PR DESCRIPTION
should have been changed in https://github.com/Vincit/objection.js/commit/b6d93b10b042e3b6d077f047df9ae5d5e98dae06