### PR TITLE
Bugfix: Include related virtualAttributes in toJSON() calls

### DIFF
--- a/lib/model/modelToJson.js
+++ b/lib/model/modelToJson.js
@@ -8,7 +8,7 @@ function toJson(model, optIn) {
   const modelClass = model.constructor;
 
   const opt = {
-    virtuals: getVirtuals(optIn, modelClass),
+    virtuals: getVirtuals(optIn),
     shallow: isShallow(optIn),
     omit: getOmit(optIn, modelClass),
     pick: null,
@@ -40,13 +40,13 @@ function toDatabaseJson(model, builder) {
   return mergeQueryProps(model, json, opt.omitFromJson, builder);
 }
 
-function getVirtuals(opt, modelClass) {
+function getVirtuals(opt) {
   if (!opt) {
-    return modelClass.getVirtualAttributes();
+    return true;
   } else if (Array.isArray(opt.virtuals)) {
     return opt.virtuals;
   } else if (opt.virtuals) {
-    return modelClass.getVirtualAttributes();
+    return true;
   } else {
     return null;
   }
@@ -68,6 +68,7 @@ function getPick(modelClass) {
 function toExternalJsonImpl(model, opt) {
   const json = {};
   const keys = Object.keys(model);
+  const vAttr = model.constructor.getVirtualAttributes();
 
   for (let i = 0, l = keys.length; i < l; ++i) {
     const key = keys[i];
@@ -76,8 +77,10 @@ function toExternalJsonImpl(model, opt) {
     assignJsonValue(json, key, value, opt);
   }
 
-  if (opt.virtuals !== null) {
+  if (Array.isArray(opt.virtuals)) {
     assignVirtualAttributes(json, model, opt.virtuals, opt);
+  } else if (vAttr && opt.virtuals === true) {
+    assignVirtualAttributes(json, model, vAttr, opt);
   }
 
   return json;

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -1397,6 +1397,59 @@ describe('Model', () => {
       });
     });
 
+    it('should include virtualAttributes for related models', () => {
+      class Model1 extends modelClass('Model1') {
+        static get virtualAttributes() {
+          return ['foo'];
+        }
+
+        get foo() {
+          return 'foo';
+        }
+      }
+
+      class Model2 extends modelClass('Model2') {
+        static get virtualAttributes() {
+          return ['bar'];
+        }
+
+        static get relationMappings() {
+          return {
+            model1: {
+              relation: Model.BelongsToOneRelation,
+              modelClass: Model1,
+              join: {
+                from: 'Model2.model1Id',
+                to: 'Model1.id'
+              }
+            }
+          };
+        }
+
+        get bar() {
+          return 'bar';
+        }
+      }
+
+      let model2 = Model2.fromJson({
+        a: 'a',
+        model1: {
+          b: 'b',
+          c: 'c'
+        }
+      });
+
+      expect(model2.toJSON()).to.eql({
+        a: 'a',
+        bar: 'bar',
+        model1: {
+          b: 'b',
+          c: 'c',
+          foo: 'foo'
+        }
+      });
+    });
+
     it('should include methods', () => {
       class Model1 extends Model {
         foo() {


### PR DESCRIPTION
**Bug**: When calling toJSON on a model with related objects, the related objects do not include their virtualAttributes.  

**Cause**: Due to the change introduced in https://github.com/Vincit/objection.js/commit/55303773da82e196b732803f112118fcc3bee9b2 (to close #1252), calls to `toJSON` set an array of virtualAttributes for `opt.virtuals`.  This array is then passed to child/related object `toJSON` calls.  This causes the related models to believe they were called with `toJSON({ virtuals: [<parent attributes>] })`, thus excluding their own virtualAttributes.

For example, if a `Post` belongs to one `User`, and the `User` has a virtual `fullName`,  calling `post.toJSON()` would not include `user.fullName`

I can confirm `v1.6.3` works as expected, and `v1.6.4` introduced the bug.

**Solution:**
This PR partially reverts https://github.com/Vincit/objection.js/commit/55303773da82e196b732803f112118fcc3bee9b2 to allow for virtualAttributes to be calculated on a per-model basis by default.  

Another solution would be to entirely revert 55303773da82e196b732803f112118fcc3bee9b2
