### PR TITLE
Allow relation lookup to accept Model classes

### DIFF
--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -637,6 +637,10 @@ class Model {
   }
 
   static getRelation(name) {
+    if (name instanceof Model) {
+      return name
+    }
+
     const relation = this.getRelationUnsafe(name);
 
     if (!relation) {


### PR DESCRIPTION
This allows `person.$relatedQuery(Movie).relate(50)`, to use the example from the docs. Using `instanceof Model` ensures all Model subclasses are supported. If you would have used `this`, only subclasses of that particular Model would work, which is not want you want. In the example above, that would mean only `Person` instances would be accepted, and not `Movie`s.
