### PR TITLE
Added type definition for aliasFor()

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -910,6 +910,7 @@ declare namespace Objection {
     first(): QueryBuilderYieldingOneOrNone<QM>;
 
     alias(alias: string): this;
+    aliasFor(modelClassOrTableName: string | ModelClass<any>, alias:string): this;
     tableRefFor(modelClass: ModelClass<any>): string;
     tableNameFor(modelClass: ModelClass<any>): string;
 


### PR DESCRIPTION
I noticed there was no type definition for aliasFor() so I have added it to the typings.