### PR TITLE
Update typings for Union, Union All and Intersect

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1099,9 +1099,9 @@ declare namespace Objection {
     orderByRaw: RawMethod<QM, RM, RV>;
 
     // Union
-    union: Union<QM>;
-    unionAll(callback: () => void): this;
-    intersect: Intersect<QM>;
+    union: SetOperations<QM>;
+    unionAll: SetOperations<QM>;
+    intersect: SetOperations<QM>;
 
     // Having
     having: Where<QM, RM, RV>;
@@ -1299,21 +1299,7 @@ declare namespace Objection {
     (column: ColumnRef, direction?: string): QueryBuilder<QM, RM, RV>;
   }
 
-  interface Union<QM extends Model> {
-    (
-      callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void,
-      wrap?: boolean
-    ): QueryBuilder<QM, QM[]>;
-    (
-      callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[],
-      wrap?: boolean
-    ): QueryBuilder<QM, QM[]>;
-    (
-      ...callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[]
-    ): QueryBuilder<QM, QM[]>;
-  }
-
-  interface Intersect<QM extends Model> {
+  interface SetOperations<QM extends Model> {
     (
       callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void,
       wrap?: boolean

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1101,7 +1101,7 @@ declare namespace Objection {
     // Union
     union: Union<QM>;
     unionAll(callback: () => void): this;
-    intersect(callback: () => void): this;
+    intersect: Intersect<QM>;
 
     // Having
     having: Where<QM, RM, RV>;
@@ -1300,6 +1300,20 @@ declare namespace Objection {
   }
 
   interface Union<QM extends Model> {
+    (
+      callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[],
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      ...callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[]
+    ): QueryBuilder<QM, QM[]>;
+  }
+
+  interface Intersect<QM extends Model> {
     (
       callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void,
       wrap?: boolean


### PR DESCRIPTION
Knex [unionAll](https://knexjs.org/#Builder-unionAll) and [intersect](https://github.com/tgriesser/knex/pull/3023) accept list of callbacks, builders or raw statements, same as union. I wanted to use the intersect method but realized it only accepted callback. So, updated the typings.