### PR TITLE
Consistently handle ModifierNotFoundError in relations

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -130,6 +130,10 @@ class Relation {
       builder.resolve([]);
     }
 
+    return this.applyModify(builder);
+  }
+
+  applyModify(builder) {
     try {
       return builder.modify(this.modify);
     } catch (err) {
@@ -151,14 +155,14 @@ class Relation {
       ownerTable = builder.tableRefFor(this.ownerModelClass.getTableName())
     } = {}
   ) {
-    let relatedSelect = relatedJoinSelectQuery.modify(this.modify).as(relatedTableAlias);
+    let relatedJoinSelect = this.applyModify(relatedJoinSelectQuery).as(relatedTableAlias);
 
-    if (relatedSelect.isSelectAll()) {
+    if (relatedJoinSelect.isSelectAll()) {
       // No need to join a subquery if the query is `select * from "RelatedTable"`.
-      relatedSelect = aliasedTableName(relatedTable, relatedTableAlias);
+      relatedJoinSelect = aliasedTableName(relatedTable, relatedTableAlias);
     }
 
-    return builder[joinOperation](relatedSelect, join => {
+    return builder[joinOperation](relatedJoinSelect, join => {
       const relatedProp = this.relatedProp;
       const ownerProp = this.ownerProp;
 

--- a/lib/relations/manyToMany/ManyToManyRelation.js
+++ b/lib/relations/manyToMany/ManyToManyRelation.js
@@ -93,7 +93,7 @@ class ManyToManyRelation extends Relation {
       builder.resolve([]);
     }
 
-    return builder.modify(this.modify);
+    return this.applyModify(builder);
   }
 
   join(
@@ -107,7 +107,7 @@ class ManyToManyRelation extends Relation {
       joinTableAlias = defaultJoinTableAlias(this, relatedTableAlias, builder)
     } = {}
   ) {
-    let relatedJoinSelect = relatedJoinSelectQuery.modify(this.modify).as(relatedTableAlias);
+    let relatedJoinSelect = this.applyModify(relatedJoinSelectQuery).as(relatedTableAlias);
 
     if (relatedJoinSelect.isSelectAll()) {
       // No need to join a subquery if the query is `select * from "RelatedTable"`.


### PR DESCRIPTION
@koskimas we talked about this today on Slack. This seems like the cleanest solution to me, as there are parts in the library that rely on being able to distinguish `ModifierNotFoundError`  from other `Error` objects.