### PR TITLE
Improve union/unionAll types

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -170,6 +170,52 @@ async () => {
   takesMaybePerson(await Person.query().findOne({ lastName }));
 };
 
+// union/unionAll types
+
+async () => {
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      // supports callbacks, or querybuilders along-side each other.
+      Person.query().where({ lastName: 'doe' }),
+      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+    );
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      // multiple query builders
+      Person.query().where({ lastName: 'doe' }),
+      Person.query().where({ lastName: 'black' }),
+    );
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      // supports callbacks, or querybuilders along-side each other.
+      (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
+      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+    );
+  // checks for unions that include wrap options
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      [
+        (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
+        (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+      ],
+      true,
+    );
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+      true,
+    );
+  await Person.query().where({ lastName: 'finnigan' })
+    .union(
+      // allows `wrap` to be passed as the last argument alongside
+      // other forms of unions. supports up to 7 union args before wrap arg.
+      Person.query().where({ lastName: 'doe' }),
+      (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
+      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+      true,
+    );
+};
+
 // .query().castTo()
 async () => {
   const animals = await Person.query()

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -173,46 +173,49 @@ async () => {
 // union/unionAll types
 
 async () => {
-  await Person.query().where({ lastName: 'finnigan' })
+  await Person.query()
+    .where({ lastName: 'finnigan' })
     .union(
       // supports callbacks, or querybuilders along-side each other.
       Person.query().where({ lastName: 'doe' }),
-      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+      qb => qb.table(Person.tableName).where({ lastName: 'black' })
     );
-  await Person.query().where({ lastName: 'finnigan' })
+  await Person.query()
+    .where({ lastName: 'finnigan' })
     .union(
       // multiple query builders
       Person.query().where({ lastName: 'doe' }),
-      Person.query().where({ lastName: 'black' }),
+      Person.query().where({ lastName: 'black' })
     );
-  await Person.query().where({ lastName: 'finnigan' })
+  await Person.query()
+    .where({ lastName: 'finnigan' })
     .union(
       // supports callbacks, or querybuilders along-side each other.
-      (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
-      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+      qb => qb.table(Person.tableName).where({ lastName: 'doe' }),
+      qb => qb.table(Person.tableName).where({ lastName: 'black' })
     );
   // checks for unions that include wrap options
-  await Person.query().where({ lastName: 'finnigan' })
+  await Person.query()
+    .where({ lastName: 'finnigan' })
     .union(
       [
-        (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
-        (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
+        qb => qb.table(Person.tableName).where({ lastName: 'doe' }),
+        qb => qb.table(Person.tableName).where({ lastName: 'black' })
       ],
-      true,
+      true
     );
-  await Person.query().where({ lastName: 'finnigan' })
-    .union(
-      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
-      true,
-    );
-  await Person.query().where({ lastName: 'finnigan' })
+  await Person.query()
+    .where({ lastName: 'finnigan' })
+    .union(qb => qb.table(Person.tableName).where({ lastName: 'black' }), true);
+  await Person.query()
+    .where({ lastName: 'finnigan' })
     .union(
       // allows `wrap` to be passed as the last argument alongside
       // other forms of unions. supports up to 7 union args before wrap arg.
       Person.query().where({ lastName: 'doe' }),
-      (qb) => qb.table(Person.tableName).where({ lastName: 'doe' }),
-      (qb) => qb.table(Person.tableName).where({ lastName: 'black' }),
-      true,
+      qb => qb.table(Person.tableName).where({ lastName: 'doe' }),
+      qb => qb.table(Person.tableName).where({ lastName: 'black' }),
+      true
     );
 };
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1310,22 +1310,14 @@ declare namespace Objection {
     (columns: ({ column: ColumnRef; order?: string } | string)[]): QueryBuilder<QM, RM, RV>;
   }
 
-  type QBOrCallback<QM extends Model> = QueryBuilder<QM, QM[]> |
-    ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void);
+  type QBOrCallback<QM extends Model> =
+    | QueryBuilder<QM, QM[]>
+    | ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void);
 
   interface Union<QM extends Model> extends BaseSetOperations<QM> {
-    (
-      ...args: QBOrCallback<QM>[]
-    ): QueryBuilder<QM, QM[]>;
-    (
-      arg1: QBOrCallback<QM>,
-      wrap?: boolean
-    ): QueryBuilder<QM, QM[]>;
-    (
-      arg1: QBOrCallback<QM>,
-      arg2: QBOrCallback<QM>,
-      wrap?: boolean
-    ): QueryBuilder<QM, QM[]>;
+    (...args: QBOrCallback<QM>[]): QueryBuilder<QM, QM[]>;
+    (arg1: QBOrCallback<QM>, wrap?: boolean): QueryBuilder<QM, QM[]>;
+    (arg1: QBOrCallback<QM>, arg2: QBOrCallback<QM>, wrap?: boolean): QueryBuilder<QM, QM[]>;
     (
       arg1: QBOrCallback<QM>,
       arg2: QBOrCallback<QM>,

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1109,8 +1109,8 @@ declare namespace Objection {
     orderByRaw: RawMethod<QM, RM, RV>;
 
     // Union
-    union: SetOperations<QM>;
-    unionAll: SetOperations<QM>;
+    union: Union<QM>;
+    unionAll: Union<QM>;
     intersect: SetOperations<QM>;
 
     // Having
@@ -1310,7 +1310,71 @@ declare namespace Objection {
     (columns: ({ column: ColumnRef; order?: string } | string)[]): QueryBuilder<QM, RM, RV>;
   }
 
-  interface SetOperations<QM extends Model> {
+  type QBOrCallback<QM extends Model> = QueryBuilder<QM, QM[]> |
+    ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void);
+
+  interface Union<QM extends Model> extends BaseSetOperations<QM> {
+    (
+      ...args: QBOrCallback<QM>[]
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      arg3: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      arg3: QBOrCallback<QM>,
+      arg4: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      arg3: QBOrCallback<QM>,
+      arg4: QBOrCallback<QM>,
+      arg5: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      arg3: QBOrCallback<QM>,
+      arg4: QBOrCallback<QM>,
+      arg5: QBOrCallback<QM>,
+      arg6: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+    (
+      arg1: QBOrCallback<QM>,
+      arg2: QBOrCallback<QM>,
+      arg3: QBOrCallback<QM>,
+      arg4: QBOrCallback<QM>,
+      arg5: QBOrCallback<QM>,
+      arg6: QBOrCallback<QM>,
+      arg7: QBOrCallback<QM>,
+      wrap?: boolean
+    ): QueryBuilder<QM, QM[]>;
+  }
+
+  interface SetOperations<QM extends Model> extends BaseSetOperations<QM> {
+    (
+      ...callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[]
+    ): QueryBuilder<QM, QM[]>;
+  }
+
+  interface BaseSetOperations<QM extends Model> {
     (
       callback: (this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void,
       wrap?: boolean
@@ -1318,9 +1382,6 @@ declare namespace Objection {
     (
       callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[],
       wrap?: boolean
-    ): QueryBuilder<QM, QM[]>;
-    (
-      ...callbacks: ((this: QueryBuilder<QM, QM[]>, queryBuilder: QueryBuilder<QM, QM[]>) => void)[]
     ): QueryBuilder<QM, QM[]>;
   }
 


### PR DESCRIPTION
### Description

Matching union/unionAll types to be closer to what the Objection/Knex api actually supports.

Previously, those methods on QueryBuilder didn't support supplying a QueryBuilder directly in the types. In plain Javascript, I've tested the calls itself, and union/unionAll support many arguments passed... each of which can be a QueryBuilder, or a callback. Also in this fashion, `wrap` argument can be provided last in the argument list as well.

I've included the capability to have up to 7 union arguments, and then an additional `wrap` boolean. Typescript doesn't allow having any amounts of arguments, then specifying the last item, unfortunately. the use of 7 amount of arguments is fairly common as far as I'm aware.

 #### Related issues

No related issues.

 ### Checklist

 - [x] New tests added or existing tests modified to cover all changes
 - [x] Code conforms with the ESLint and Prettier rules (`npm eslint` passes
      and `npm prettier` has been applied)