### PR TITLE
Make graph options more strict

### DIFF
--- a/lib/queryBuilder/graph/GraphOptions.js
+++ b/lib/queryBuilder/graph/GraphOptions.js
@@ -162,8 +162,14 @@ class GraphOptions {
 
     if (Array.isArray(option)) {
       return option.indexOf(node.relationPathKey) !== -1;
+    } else if (typeof option === 'boolean') {
+      return option;
+    } else if (option === undefined) {
+      return false;
     } else {
-      return !!option;
+      throw new Error(
+        `invalid option for ${optionName}: ${option}. please provide a boolean or array of strings.`
+      );
     }
   }
 }

--- a/lib/queryBuilder/graph/GraphOptions.js
+++ b/lib/queryBuilder/graph/GraphOptions.js
@@ -168,7 +168,7 @@ class GraphOptions {
       return false;
     } else {
       throw new Error(
-        `invalid option for ${optionName}: ${option}. please provide a boolean or array of strings.`
+        `expected ${optionName} option value "${option}" to be an instance of boolean or array of strings`
       );
     }
   }

--- a/tests/integration/upsertGraph.js
+++ b/tests/integration/upsertGraph.js
@@ -2526,6 +2526,29 @@ module.exports = session => {
             });
           });
         });
+
+        it('should throw a sensible error if an option with an invalid type is passed', done => {
+          Model1.bindKnex(session.knex)
+            .query()
+            .upsertGraph(
+              {
+                id: 1
+              },
+              {
+                noRelate: 'model1Relation2'
+              }
+            )
+            .then(() => {
+              throw new Error('should not get here');
+            })
+            .catch(err => {
+              expect(err.message).to.equal(
+                'expected noRelate option value "model1Relation2" to be an instance of boolean or array of strings'
+              );
+              done();
+            })
+            .catch(done);
+        });
       }
 
       describe('relate with children => upsertGraph recursively called', () => {


### PR DESCRIPTION
Verify that an option being passed is indeed `undefined`, a boolean or an array of strings.

Previously if you specified an option such as `noUpdate: '[files]'`, it would be gladly accepted and `!!`-ed. Being familiar with arrays within a single RelationExpression from e.g. `eager()` makes this likely to occur (e.g. https://github.com/elifesciences/elife-xpub/pull/2173/files#diff-5b518139d4766e3a75dc9c2cb1213c90R68), be hard to find and cause data loss.

The correct way to specify that you only don't want to update the `files` is `noUpdate: ['files']`, an array of strings.

This PR verifies that you're passing options of the correct type.

Perhaps there's a bigger type-checking for options discussion to be had, but this is what bit us, so I figured it would be an OK place to start. :)