### PR TITLE
Add MySQL service to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ notifications:
 
 addons:
   postgresql: '9.5'
+
+services:
+  - mysql


### PR DESCRIPTION
Recently MySQL isn't started by default in Travis and needs to be specified manually.