### PR TITLE
Fix GitHub's name on the website

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -5,7 +5,7 @@ module.exports = {
 
   themeConfig: {
     repo: 'vincit/objection.js',
-    repoLabel: 'Github',
+    repoLabel: 'GitHub',
 
     algolia: {
       apiKey: '8b9b4ac9f68d11c702e8102479760861',


### PR DESCRIPTION
The name is [officially](https://en.wikipedia.org/wiki/GitHub) "GitHub", not "Github".