### PR TITLE
joinRelation types no longer weakend

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -134,6 +134,13 @@ const lastName = 'Lawrence';
 
 takesPersonQueryBuilder(Person.query());
 
+// ensure `joinRelation` and friends returns the correct QueryBuilder types
+takesPersonQueryBuilder(
+  Person.query()
+    .where({ lastName })
+    .joinRelation('children')
+);
+
 async () => {
   takesPeople(await Person.query().where('lastName', lastName));
   takesPeople(await Person.query().where({ lastName }));

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -347,7 +347,11 @@ declare namespace Objection {
   }
 
   interface JoinRelation {
-    <QM extends Model>(relationName: string, opt?: RelationOptions): QueryBuilder<QM, QM[]>;
+    <TBase extends Model, QM extends TBase>(
+      this: QueryBuilder<TBase>,
+      relationName: string,
+      opt?: RelationOptions
+    ): QueryBuilder<QM, QM[]>;
   }
 
   type JsonObjectOrFieldExpression = object | object[] | FieldExpression;


### PR DESCRIPTION
### Description

`joinRelation` and other similar methods returned a queryBuilder type with just `Model`. This fix preserves the actual base model the query is being made on.

e.g. `Person.query().joinRelation('children')` will return `QueryBuilder<Person, Person[], Person[]>` now (Person class in test types used for this example).

As much as I'd like to be able to actually strengthen the types returned (e.g.  Person returned with a guaranteed `children` prop as `Person[]` not optional), the style of using a string with its own language as the argument for eager/relational calls prevents typescript from being able to infer this at this time.

 #### Related issues

 - Related to https://github.com/Vincit/objection.js/issues/1339

 ### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the ESLint and Prettier rules (`npm eslint` passes and `npm prettier` has been applied)