### PR TITLE
Types require less casting, as well as handles invalid (existing) props passed error

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -22,6 +22,8 @@ import * as ajv from 'ajv';
 
 export = Objection;
 
+type DeriveModelType<T> = T extends Array<unknown> ? T[number] : T;
+
 declare namespace Objection {
   const lit: LiteralBuilder;
   const raw: knex.RawBuilder;
@@ -615,14 +617,15 @@ declare namespace Objection {
      * If you add fields to your model, you get $relatedQuery typings for
      * free.
      *
-     * Note that if you make any chained calls to the QueryBuilder,
-     * though, you should apply a cast, which will make your code use not this
-     * signatue, but the following signature.
+     * Chained calls to QueryBuilder can now use this version of $relatedQuery,
+     * without having to force cast a Type anymore. These typings also work properly
+     * in cases where the relation type is an array (this will derive individual
+     * type from within the array type).
      */
-    $relatedQuery<K extends keyof this, V extends this[K] & Model>(
+    $relatedQuery<K extends keyof this, V extends this[K], R = DeriveModelType<V>>(
       relationName: K,
       trxOrKnex?: Transaction | knex
-    ): QueryBuilder<V, V, V>;
+    ): R extends Model ? QueryBuilder<R, V> : never;
 
     /**
      * Builds a query that only affects the models related to this instance


### PR DESCRIPTION
### Description

The types for `$relatedQuery` (without the force cast) didn't handle type inference very well, also returning a QueryBuilder with types that made chaining subsequent calls problematic/error incorrectly.

With the changes in this PR, `$relatedQuery` (without force cast) no longer has complications for subsequent chained calls. It returns the correct QueryBuilder by using the property name, grabbing that property type from the class defined (supports property types being an array of models or singular), and ensures that type extends `Model`. This significantly reduces the situations needing force-casting for `$relatedQuery`.

A new addition to the types here is if a relation name is passed, which exists as a property on the model, but does not actually extend `Model`, `$relatedQuery` will return `never`. This way the types will alert the developer when they've specified something which isn't query-able.

This PR has two assumptions involved:
 - Any relation available for `$relatedQuery` will also be included in the types of the model class itself.
 - The type of the relation specified will have extended `Model`.

If any of the assumptions are undesirable by the developer, they can use the force-cast version of `$relatedQuery`. e.g: `await child.$relatedQuery<Person>('parent');` (though this case would work perfectly fine without the force cast unless types aren't defined).

 #### Related issues

 - Related to https://github.com/Vincit/objection.js/issues/856

 ### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the ESLint and Prettier rules (`npm eslint` passes and `npm prettier` has been applied)