### PR TITLE
Add total number of pages to .page() return object

### DIFF
--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -716,7 +716,7 @@ class QueryBuilder extends QueryBuilderBase {
     const range = this.range(+page * +pageSize, (+page + 1) * +pageSize - 1)
     return {
       ...range,
-      pages: range.total / pageSize
+      pages: Math.ceil(range.total / pageSize)
     }
   }
 

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -713,11 +713,11 @@ class QueryBuilder extends QueryBuilderBase {
   }
 
   page(page, pageSize) {
-    const range = this.range(+page * +pageSize, (+page + 1) * +pageSize - 1)
+    const range = this.range(+page * +pageSize, (+page + 1) * +pageSize - 1);
     return {
       ...range,
       pages: Math.ceil(range.total / pageSize)
-    }
+    };
   }
 
   columnInfo({ table = null } = {}) {

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -713,7 +713,11 @@ class QueryBuilder extends QueryBuilderBase {
   }
 
   page(page, pageSize) {
-    return this.range(+page * +pageSize, (+page + 1) * +pageSize - 1);
+    const range = this.range(+page * +pageSize, (+page + 1) * +pageSize - 1)
+    return {
+      ...range,
+      pages: range.total / pageSize
+    }
   }
 
   columnInfo({ table = null } = {}) {

--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -866,6 +866,7 @@ describe('QueryBuilder', () => {
         ]);
         expect(res.total).to.equal(123);
         expect(res.results).to.eql([{ a: 1 }]);
+        expect(res.pages).to.eql(2);
         done();
       })
       .catch(done);


### PR DESCRIPTION
This is pretty useful considering I have to manually calculate this each time I use the paging operation at the moment.