### PR TITLE
Add missing typings

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -54,7 +54,7 @@ class Person extends objection.Model {
   examplePersonMethod = (arg: string) => 1;
 
   static staticExamplePersonMethod() {
-    return 100
+    return 100;
   }
 
   petsWithId(petId: number): Promise<Animal[]> {
@@ -704,7 +704,6 @@ pagePromise = pageQb.execute();
 
 const modelFromQuery = qb.modelClass();
 
-
 const sql: string = qb.toSql();
 const tableName: string = qb.tableNameFor(Person);
 const tableRef: string = qb.tableRefFor(Person);
@@ -859,6 +858,17 @@ Person.query().select(
 Person.query().where(builder => {
   builder.whereBetween('age', [30, 40]).orWhereIn('lastName', whereSubQuery);
 });
+
+/**
+ * http://knexjs.org/#Builder-count
+ */
+Person.query().count('active', { as: 'a' });
+Person.query().count('active as a');
+Person.query().count({ a: 'active' });
+Person.query().count({ a: 'active', v: 'valid' });
+Person.query().count('id', 'active');
+Person.query().count({ count: ['id', 'active'] });
+Person.query().count(raw('??', ['active']));
 
 // RawBuilder:
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -436,6 +436,16 @@ declare namespace Objection {
     (insert: PartialModelObject<ModelType<QB>>[]): ArrayQueryBuilder<QB>;
   }
 
+  interface RelateMethod<QB extends AnyQueryBuilder> {
+    <RelatedModel extends Model>(
+      ids: MaybeCompositeId | Partial<RelatedModel> | Partial<RelatedModel>[]
+    ): SingleQueryBuilder<QB>;
+
+    <RelatedModel extends Model>(
+      ids: MaybeCompositeId | Partial<RelatedModel> | Partial<RelatedModel>[]
+    ): ArrayQueryBuilder<QB>;
+  }
+
   interface EagerMethod<QB extends AnyQueryBuilder> {
     (expr: RelationExpression<ModelType<QB>>, modifiers?: Modifiers): QB;
   }
@@ -699,6 +709,8 @@ declare namespace Objection {
 
     insert: InsertMethod<this>;
     insertAndFetch: InsertMethod<this>;
+
+    relate: RelateMethod<this>;
 
     eager: EagerMethod<this>;
     mergeEager: EagerMethod<this>;

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -221,6 +221,13 @@ declare namespace Objection {
     <M extends Model>(modelClass: ModelClass<M>): M['QueryBuilderType'];
   }
 
+  /**
+   * https://vincit.github.io/objection.js/api/types/#type-fieldexpression
+   */
+  type FieldExpression = string;
+
+  type JsonObjectOrFieldExpression = object | object[] | FieldExpression;
+
   type Selection<QB extends AnyQueryBuilder> = ColumnRef | AnyQueryBuilder | CallbackVoid<QB>;
 
   interface SelectMethod<QB extends AnyQueryBuilder> {
@@ -276,6 +283,21 @@ declare namespace Objection {
     (col: ColumnRef | ColumnRef[], value: Value[]): QB;
     (col: ColumnRef | ColumnRef[], cb: CallbackVoid<QB>): QB;
     (col: ColumnRef | ColumnRef[], qb: AnyQueryBuilder): QB;
+  }
+
+  interface WhereBetweenMethod<QB extends AnyQueryBuilder> {
+    (column: ColumnRef, range: [Value, Value]): QB;
+  }
+
+  interface WhereJsonSupersetOfMethod<QB extends AnyQueryBuilder> {
+    (
+      fieldExpression: FieldExpression,
+      jsonObjectOrFieldExpression: JsonObjectOrFieldExpression
+    ): QB;
+  }
+
+  interface WhereJsonIsArrayMethod<QB extends AnyQueryBuilder> {
+    (fieldExpression: FieldExpression): QB;
   }
 
   type QBOrCallback<QB extends AnyQueryBuilder> = AnyQueryBuilder | CallbackVoid<QB>;
@@ -350,6 +372,12 @@ declare namespace Objection {
 
   interface IncrementDecrementMethod<QB extends AnyQueryBuilder> {
     (column: string, amount?: number): QB;
+  }
+
+  interface CountMethod<QB extends AnyQueryBuilder> {
+    (column?: ColumnRef, options?: { as: string }): QB;
+    (aliasToColumnDict: { [alias: string]: string | string[] }): QB;
+    (...columns: ColumnRef[]): QB;
   }
 
   interface OrderByMethod<QB extends AnyQueryBuilder> {
@@ -562,7 +590,10 @@ declare namespace Objection {
   }
 
   interface ModifyEagerMethod<QB extends AnyQueryBuilder> {
-    <M extends Model>(expr: RelationExpression<ModelType<QB>>, modifier: Modifier<M['QueryBuilderType']>): QB;
+    <M extends Model>(
+      expr: RelationExpression<ModelType<QB>>,
+      modifier: Modifier<M['QueryBuilderType']>
+    ): QB;
   }
 
   interface ContextMethod<QB extends AnyQueryBuilder> {
@@ -610,6 +641,11 @@ declare namespace Objection {
     whereNotIn: WhereInMethod<this>;
     orWhereNotIn: WhereInMethod<this>;
 
+    whereBetween: WhereBetweenMethod<this>;
+
+    whereJsonSupersetOf: WhereJsonSupersetOfMethod<this>;
+    whereJsonIsArray: WhereJsonIsArrayMethod<this>;
+
     union: UnionMethod<this>;
     unionAll: UnionMethod<this>;
 
@@ -633,6 +669,7 @@ declare namespace Objection {
     fullOuterJoin: JoinMethod<this>;
     crossJoin: JoinMethod<this>;
 
+    count: CountMethod<this>;
     increment: IncrementDecrementMethod<this>;
     decrement: IncrementDecrementMethod<this>;
 
@@ -686,7 +723,7 @@ declare namespace Objection {
     as: OneArgMethod<string, this>;
     alias: OneArgMethod<string, this>;
     withSchema: OneArgMethod<string, this>;
-    modelClass: ModelClassMethod
+    modelClass: ModelClassMethod;
     tableNameFor: TableRefForMethod;
     tableRefFor: TableRefForMethod;
     toSql: StringReturningMethod;
@@ -974,6 +1011,7 @@ declare namespace Objection {
     static JoinEagerAlgorithm: EagerAlgorithm;
 
     static query: StaticQueryMethod;
+    static relatedQuery: RelatedQueryMethod<Model>;
     static columnNameMappers: ColumnNameMappers;
     static relationMappings: RelationMappings | (() => RelationMappings);
 
@@ -1024,4 +1062,8 @@ declare namespace Objection {
 
     QueryBuilderType: QueryBuilder<this, this[]>;
   }
+
+  export interface transaction<T> {}
+
+  export const transaction: transaction<any>;
 }

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1022,6 +1022,7 @@ declare namespace Objection {
     static tableMetadata(opt?: TableMetadataOptions): TableMetadata;
     static fetchTableMetadata(opt?: FetchTableMetadataOptions): Promise<TableMetadata>;
 
+    static knex(knex?: knex): knex;
     static bindKnex: BindKnexMethod;
     static bindTransaction: BindKnexMethod;
     static loadRelated: StaticLoadRelatedMethod;
@@ -1063,7 +1064,96 @@ declare namespace Objection {
     QueryBuilderType: QueryBuilder<this, this[]>;
   }
 
-  export interface transaction<T> {}
+  /**
+   * Overloading is required here until the following issues (at least) are resolved:
+   *
+   * - https://github.com/microsoft/TypeScript/issues/1360
+   * - https://github.com/Microsoft/TypeScript/issues/5453
+   *
+   * @tutorial https://vincit.github.io/objection.js/guide/transactions.html#creating-a-transaction
+   */
+  export interface transaction {
+    start(knexOrModel: knex | ModelClass<any>): Promise<Transaction>;
 
-  export const transaction: transaction<any>;
+    <MC1 extends ModelClass<any>, ReturnValue>(
+      modelClass1: MC1,
+      callback: (boundModelClass: MC1, trx?: Transaction) => Promise<ReturnValue>
+    ): Promise<ReturnValue>;
+
+    <MC1 extends ModelClass<any>, MC2 extends ModelClass<any>, ReturnValue>(
+      modelClass1: MC1,
+      modelClass2: MC2,
+      callback: (
+        boundModelClass1: MC1,
+        boundModelClass2: MC2,
+        trx?: Transaction
+      ) => Promise<ReturnValue>
+    ): Promise<ReturnValue>;
+
+    <
+      MC1 extends ModelClass<any>,
+      MC2 extends ModelClass<any>,
+      MC3 extends ModelClass<any>,
+      ReturnValue
+    >(
+      modelClass1: MC1,
+      modelClass2: MC2,
+      modelClass3: MC3,
+      callback: (
+        boundModelClass1: MC1,
+        boundModelClass2: MC2,
+        boundModelClass3: MC3,
+        trx?: Transaction
+      ) => Promise<ReturnValue>
+    ): Promise<ReturnValue>;
+
+    <
+      MC1 extends ModelClass<any>,
+      MC2 extends ModelClass<any>,
+      MC3 extends ModelClass<any>,
+      MC4 extends ModelClass<any>,
+      ReturnValue
+    >(
+      modelClass1: MC1,
+      modelClass2: MC2,
+      modelClass3: MC3,
+      modelClass4: MC4,
+      callback: (
+        boundModelClass1: MC1,
+        boundModelClass2: MC2,
+        boundModelClass3: MC3,
+        boundModelClass4: MC4,
+        trx?: Transaction
+      ) => Promise<ReturnValue>
+    ): Promise<ReturnValue>;
+
+    <
+      MC1 extends ModelClass<any>,
+      MC2 extends ModelClass<any>,
+      MC3 extends ModelClass<any>,
+      MC4 extends ModelClass<any>,
+      MC5 extends ModelClass<any>,
+      ReturnValue
+    >(
+      modelClass1: MC1,
+      modelClass2: MC2,
+      modelClass3: MC3,
+      modelClass4: MC4,
+      modelClass5: MC5,
+      callback: (
+        boundModelClass1: MC1,
+        boundModelClass2: MC2,
+        boundModelClass3: MC3,
+        boundModelClass4: MC4,
+        boundModelClass5: MC5,
+        trx?: Transaction
+      ) => Promise<ReturnValue>
+    ): Promise<ReturnValue>;
+
+    <ReturnValue>(knex: knex, callback: (trx: Transaction) => Promise<ReturnValue>): Promise<
+      ReturnValue
+    >;
+  }
+
+  export const transaction: transaction;
 }


### PR DESCRIPTION
I wanted to get this PR open so there is visibility into the work being done. The new typings seem much cleaner than the old ones so I wanted to make sure I kept that cleanliness. _Please let me know if this is looking good so far._ If so, I will continue to work on it until `npm run test-typings` passes (or I get tired 😄 )

So far I've added support for:
- `whereBetween`
- `whereJsonSupersetOf`
- `whereJsonIsArray`
- `count`
- `static relatedQuery`
- `transaction`
- `relate`
