### PR TITLE
fix findById return type for composite key

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -426,7 +426,7 @@ async () => {
 
 const maybePerson: Promise<Person | undefined> = qb.findById(1);
 
-const maybePeople: Promise<Person[]> = qb.findById([1, 2, 3]);
+const maybePeople: Promise<Person[]> = qb.findByIds([1, 2, 3]);
 
 // query builder knex-wrapping methods:
 
@@ -1032,4 +1032,33 @@ const plugin2 = ({} as any) as objection.Plugin;
   takesModelClass(MyPerson);
   takesPersonClass(MyPerson);
   takesModelSubclass(new MyPerson());
+};
+
+// Examples with composite key
+class Interview extends objection.Model {
+  interviewer!: Person;
+  interviewee!: Person;
+  interviewDate?: number;
+
+  static columnNameMappers = objection.snakeCaseMappers();
+
+  static idColumn = ['interviewer', 'interviewee'];
+}
+
+async () => {
+  // findById with composite key
+  const interview: Interview | undefined = await Interview.query().findById([10, 11]);
+
+  // findById with composite key, chained with other query builder methods
+  const interviewWithAssignedDate: Interview | undefined = await Interview.query()
+    .findById([10, 11])
+    .whereNotNull('interviewDate');
+
+  // findByIds with sets of composite key
+  const interviews: Interview[] = await Interview.query().findByIds([[10, 11], [11, 12], [12, 13]]);
+
+  // findByIds with sets of composite key, chained with other query builder methods
+  const interviewsWithAssignedDate: Interview[] = await Interview.query()
+    .findByIds([[10, 11], [11, 12], [12, 13]])
+    .whereNotNull('interviewDate');
 };

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -1036,8 +1036,8 @@ const plugin2 = ({} as any) as objection.Plugin;
 
 // Examples with composite key
 class Interview extends objection.Model {
-  interviewer!: Person;
-  interviewee!: Person;
+  interviewer!: number;
+  interviewee!: number;
   interviewDate?: number;
 
   static columnNameMappers = objection.snakeCaseMappers();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -731,8 +731,7 @@ declare namespace Objection {
 
     applyFilter(...namedFilters: string[]): this;
 
-    findById(id: Id): QueryBuilderYieldingOneOrNone<QM>;
-    findById(idOrIds: IdOrIds): this;
+    findById(idOrIds: IdOrIds): QueryBuilderYieldingOneOrNone<QM>;
     findByIds(ids: Id[] | Id[][]): this;
     /** findOne is shorthand for .where(...whereArgs).first() */
     findOne: FindOne<QM>;


### PR DESCRIPTION
### Description
This problem lies in the TypeScript type definition only.

`QueryBuilder`'s method [`findById`](https://github.com/Vincit/objection.js/blob/master/typings/objection/index.d.ts#L734-L735) currently accepts both an [`Id`](https://github.com/Vincit/objection.js/blob/master/typings/objection/index.d.ts#L339) (for single-field key) and an [`Ids`](https://github.com/Vincit/objection.js/blob/master/typings/objection/index.d.ts#L341) (for composite key).

Both versions return `this` for method chaining, however, only the "single-field key" version is overloaded to return a `QueryBuilderYieldingOneOrNone<QM>`. Such overloading breaks this use case for composite key:

```typescript
class SomeModel extends objection.Model {
  static idColumn = ['idField1', 'idField2'];
  // ...
}

function someFunctionNeedsModel(model: SomeModel | undefined) {
  // do something
}

// With .then()
SomeModel.query()
  .findById([1, 1])
  .then(model => {
    someFunctionNeedsModel(model);
  });

// With Promise
someFunctionNeedsModel(await SomeModel.query().findById([1, 1]));
```

`findById` should always return a `QueryBuilderYieldingOneOrNone<QM>`.

This PR fixes the overload, adds related test cases, and fixes an existing test case which incorrectly uses `findById` (seems like an unfortunate typo that compiles).

#### Related issues

Relates to #1435

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the ESLint and Prettier rules (`npm eslint` passes
      and `npm prettier` has been applied)
