### PR TITLE
fix(typings): throwIfNotFound() yields one when used with first(), not one or none

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -674,7 +674,9 @@ declare namespace Objection {
   export interface QueryBuilderYieldingOne<QM extends Model> extends QueryBuilder<QM, QM, QM> {}
 
   export interface QueryBuilderYieldingOneOrNone<QM extends Model>
-    extends QueryBuilder<QM, QM, QM | undefined> {}
+    extends QueryBuilder<QM, QM, QM | undefined> {
+    throwIfNotFound(): QueryBuilderYieldingOne<QM>;
+  }
 
   export interface QueryBuilderYieldingCount<QM extends Model, RM = QM[]>
     extends QueryBuilderBase<QM, RM, number>,
@@ -1556,7 +1558,7 @@ declare namespace Objection {
      */
     type?: string | string[];
     /**
-     * fallback raw string for custom formats, 
+     * fallback raw string for custom formats,
      * or formats that aren't in the standard yet
      */
     format?: JsonSchemaFormatType | string;


### PR DESCRIPTION
I noticed when converting my project to TypeScript that if you call `.throwIfNotFound()` with something like `.first()`, it still thinks the result may not be undefined, even though we'll be throwing an error if it is not defined.

I noticed you already had `QueryBuilderYieldingOneOrNone` associated with `.first()`, so I just updated its interface to include an override for `throwIfNotFound()` to return `QueryBuilderYieldingOne` instead of just `this`

Looks like my IDE also found some extra whitespace! Let me know if you want that removed and I'll remove it :)