### PR TITLE
feat: removing required on definitions for patch validator

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -246,10 +246,18 @@ function objectHasDefaults(obj) {
 
 function jsonSchemaWithoutRequired(jsonSchema) {
   const subSchemaProps = ['anyOf', 'oneOf', 'allOf', 'not', 'then', 'else'];
-
   return Object.assign(
     omit(jsonSchema, ['required', ...subSchemaProps]),
-    ...subSchemaProps.map(prop => subSchemaWithoutRequired(jsonSchema, prop))
+    ...subSchemaProps.map(prop => subSchemaWithoutRequired(jsonSchema, prop)),
+    jsonSchema && jsonSchema.definitions
+      ? {
+          definitions: Object.assign(
+            ...Object.keys(jsonSchema.definitions).map(prop => ({
+              [prop]: jsonSchemaWithoutRequired(jsonSchema.definitions[prop])
+            }))
+          )
+        }
+      : {}
   );
 }
 

--- a/tests/unit/model/AjvValidator.js
+++ b/tests/unit/model/AjvValidator.js
@@ -1,0 +1,46 @@
+const { AjvValidator, Model } = require('../../../');
+const expect = require('expect.js');
+
+function modelClass(tableName, schema) {
+  return class TestModel extends Model {
+    static get tableName() {
+      return tableName;
+    }
+    static get jsonSchema() {
+      return schema;
+    }
+  };
+}
+
+describe('AjvValidator', () => {
+  describe('patch validator', () => {
+    const schema = {
+      definitions: {
+        TestRef1: {
+          type: 'object',
+          properties: {
+            aRequiredProp1: { type: 'string' }
+          },
+          required: ['aRequiredProp1']
+        },
+        TestRef2: {
+          type: 'object',
+          properties: {
+            aRequiredProp2: { type: 'string' }
+          },
+          required: ['aRequiredProp2']
+        }
+      },
+      anyOf: [{ $ref: '#/definitions/TestRef1' }, { $ref: '#/definitions/TestRef2' }]
+    };
+
+    it('should remove required fields from definitions', () => {
+      const validator = new AjvValidator({ onCreateAjv: () => {} });
+      const validators = validator.getValidator(modelClass('test', schema), schema, true);
+      const definitions = Object.entries(validators.schema.definitions);
+
+      expect(definitions.length).to.be(2);
+      definitions.forEach(d => expect(d.required).to.be(undefined));
+    });
+  });
+});


### PR DESCRIPTION
Modifies the AjvValidator logic that creates the patch validator to also strip the required property from any definitions found.

Fixes #1547 