### PR TITLE
fix:1572 incorrect type inference on insert

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -683,9 +683,9 @@ declare namespace Objection {
   }
 
   interface Insert<QM extends Model> {
-    (modelsOrObjects?: Partial<QM>[]): QueryBuilder<QM, QM[]>;
-    (modelOrObject?: Partial<QM>): QueryBuilder<QM, QM>;
-    (): this;
+    (modelsOrObjects: Partial<QM>[]): QueryBuilder<QM, QM[]>;
+    (modelOrObject: Partial<QM>): QueryBuilder<QM, QM>;
+    (): QueryBuilder<QM, QM>;
   }
 
   interface InsertGraph<QM extends Model> {


### PR DESCRIPTION
```
const created = await Person
  .fromJson({ firstName: 'Jennifer' })
  .$query()
  .insert();
```
The type of created is incorrectly inferred as Person[] whereas it should be Person.

Fixes #1572 