### PR TITLE
Added statusCode to CreateValidationErrorArgs

### DIFF
--- a/tests/ts/validation.ts
+++ b/tests/ts/validation.ts
@@ -62,4 +62,22 @@ import { Person } from './fixtures/person';
       }
     }
   }
+
+  // gh-1582
+  try {
+    throw new ValidationError({
+      statusCode: 409,
+      type: 'InvalidOneTimeCode',
+      message: 'Wrong code',
+      data: {
+        supplied: '1234',
+      },
+    });
+  } catch (e) {
+    if(e instanceof ValidationError) {
+      if(e.type === 'InvalidOneTimeCode') {
+        console.log('one time code was invalid');
+      }
+    }
+  }
 })();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1492,6 +1492,7 @@ declare namespace Objection {
   }
 
   export interface CreateValidationErrorArgs {
+    statusCode?: number
     message?: string;
     data?: ErrorHash | any;
     // This can be any string for custom errors. ValidationErrorType is there

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1478,7 +1478,7 @@ declare namespace Objection {
     statusCode: number;
     message: string;
     data?: ErrorHash | any;
-    type: ValidationErrorType;
+    type: ValidationErrorType | string;
   }
 
   export interface ValidationErrorItem {


### PR DESCRIPTION
To support (e.g.):

``` js
throw new ValidationError({
  statusCode: 409,  // <-- currently results in a TS error
  type: 'InvalidOneTimeCode',
  message: 'Wrong code',
  data: {
    supplied: code,
  },
});
```