### PR TITLE
[Objection2] Types: Ensure single query builder return type contains undefined

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -176,6 +176,7 @@ function takesModelClass(m: objection.ModelClass<any>) {}
 const takesPerson = (person: Person) => {
   person.examplePersonMethod('');
 };
+const takesMaybeUndefined = (_: undefined) => 1;
 const takesMaybePerson = (_: Person | undefined) => 1;
 const takesPeople = (_: Person[]) => 1;
 const takesNumber = (_: number) => 1;
@@ -204,6 +205,7 @@ async () => {
   takesPeople(await Person.query().where('lastName', lastName));
   takesPeople(await Person.query().where({ lastName }));
   takesMaybePerson(await Person.query().findById(123));
+  takesMaybeUndefined(await Person.query().findById(123));
   takesMaybePerson(await Person.query().findById('uid'));
 };
 


### PR DESCRIPTION
In Objection v2 the single query builder termination methods are typed as always returning the model:

```ts
const maybePerson = await Person.query().findById(123);
// maybePerson: Person
```

In v1 this was `maybePerson: Person | undefined`. Assuming this change was unintentional I can finish this PR to cover all the methods and pass the tests.