### PR TITLE
make startTransaction typings return a Promise

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1434,7 +1434,7 @@ declare namespace Objection {
 
     knex(knex?: knex): knex;
     knexQuery(): knex.QueryBuilder;
-    startTransaction(knexOrTransaction?: TransactionOrKnex): Transaction;
+    startTransaction(knexOrTransaction?: TransactionOrKnex): Promise<Transaction>;
 
     transaction<T>(callback: (trx: Transaction) => Promise<T>): Promise<T>;
     transaction<T>(


### PR DESCRIPTION
Judging from my experience when working with the `startTransaction` function, and from the documentation, I believe `startTransaction` returns a Promise that resolves to a `Transaction`, and not the actual `Transaction` itself.

Docs mentioning `startTransaction`, where it is awaited:

- https://vincit.github.io/objection.js/api/model/static-methods.html#static-starttransaction
- https://vincit.github.io/objection.js/guide/transactions.html#creating-a-transaction