### PR TITLE
feat: parallelize initialization of table metadata

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -6,11 +6,7 @@ async function initialize(knex, modelClasses) {
     knex = modelClasses[0].knex();
   }
 
-  const promises = modelClasses.reduce((acc, modelClass) => {
-    acc.push(modelClass.fetchTableMetadata({ knex }));
-    return acc;
-  }, []);
-  await Promise.all(promises);
+  await Promise.all(modelClasses.map(modelClass => modelClass.fetchTableMetadata({ knex })));
 }
 
 module.exports = {

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -6,11 +6,11 @@ async function initialize(knex, modelClasses) {
     knex = modelClasses[0].knex();
   }
 
-  for (const modelClass of modelClasses) {
-    await modelClass.fetchTableMetadata({
-      knex
-    });
-  }
+  const promises = modelClasses.reduce((acc, modelClass) => {
+    acc.push(modelClass.fetchTableMetadata({ knex }));
+    return acc;
+  }, []);
+  await Promise.all(promises);
 }
 
 module.exports = {


### PR DESCRIPTION
Loading tableMetadata for lots of tables is slow because it's done in serial.  This PR parallelizes the process for faster initialization