### PR TITLE
fix #1681 oneOf->not->required should be stripped off

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -274,9 +274,12 @@ function subSchemaWithoutRequired(jsonSchema, prop) {
         return {};
       }
     } else {
-      return {
-        [prop]: jsonSchemaWithoutRequired(jsonSchema[prop])
-      };
+      const withoutRequired = jsonSchemaWithoutRequired(jsonSchema[prop]);
+      return isNotEmptyObject(withoutRequired)
+        ? {
+            [prop]: withoutRequired
+          }
+        : {};
     }
   } else {
     return {};

--- a/tests/unit/model/Model.js
+++ b/tests/unit/model/Model.js
@@ -323,6 +323,24 @@ describe('Model', () => {
       }).to.not.throwException(err => console.log(err));
     });
 
+    it('should skip requirement validation if options.patch == true (oneOf -> not -> required)', () => {
+      Model1.jsonSchema = {
+        oneOf: [
+          {
+            not: { required: ['a'] }
+          }
+        ],
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' }
+        }
+      };
+
+      expect(() => {
+        Model1.fromJson({ b: 'str' }, { patch: true });
+      }).to.not.throwException(err => console.log(err));
+    });
+
     it('should skip requirement validation if options.patch == true (anyOf)', () => {
       Model1.jsonSchema = {
         anyOf: [


### PR DESCRIPTION
fixes https://github.com/Vincit/objection.js/issues/1681 and provides test case for it.

Without the change the resulting jsonSchema for:

```
{
        oneOf: [
          {
            not: { required: ['a'] }
          }
        ],
        properties: {
          a: { type: 'string' },
          b: { type: 'string' }
        }
      }
```

would look like:

```
{
  "properties": {
    "a": {
      "type": "string"
    },
    "b": {
      "type": "string"
    }
  },
  "oneOf": [
    {
      "not": {}
    }
  ]
}
```

which in essence is impossible.  

```
  "oneOf": [
    {
      "not": {}
    }
  ]
```
prevents all the updates altogether since it will fail any given payload.

This is the result after the change:

```
{
  "properties": {
    "a": {
      "type": "string"
    },
    "b": {
      "type": "string"
    }
  }
}
```