### PR TITLE
Deleting map method from documentation

### DIFF
--- a/doc/api/query-builder/other-methods.md
+++ b/doc/api/query-builder/other-methods.md
@@ -840,26 +840,6 @@ Executes the query and returns a Promise.
 | --------- | ---------------------------------------------------------- |
 | `Promise` | Promise the will be resolved with the result of the query. |
 
-## map()
-
-```js
-const promise = queryBuilder.map(mapper);
-```
-
-Executes the query and calls `map(mapper)` for the returned promise.
-
-##### Arguments
-
-| Argument | Type     | Default  | Description     |
-| -------- | -------- | -------- | --------------- |
-| mapper   | function | identity | Mapper function |
-
-##### Return value
-
-| Type      | Description                                                |
-| --------- | ---------------------------------------------------------- |
-| `Promise` | Promise the will be resolved with the result of the query. |
-
 ## reduce()
 
 ```js

--- a/doc/api/query-builder/other-methods.md
+++ b/doc/api/query-builder/other-methods.md
@@ -840,29 +840,6 @@ Executes the query and returns a Promise.
 | --------- | ---------------------------------------------------------- |
 | `Promise` | Promise the will be resolved with the result of the query. |
 
-## reduce()
-
-```js
-const promise = queryBuilder.reduce(reducer, initialValue);
-```
-
-Executes the query and calls `reduce(reducer, initialValue)` for the returned promise.
-
-##### Arguments
-
-| Argument     | Type     | Default                                 | Description       |
-| ------------ | -------- | --------------------------------------- | ----------------- |
-| reducer      | function | undefined                               | Reducer function  |
-| initialValue | any      | first element of the reduced collection | First arg for the |
-
-reducer function
-
-##### Return value
-
-| Type      | Description                                                |
-| --------- | ---------------------------------------------------------- |
-| `Promise` | Promise the will be resolved with the result of the query. |
-
 ## catch()
 
 ```js


### PR DESCRIPTION
This PR deletes map method as explained here: #1782 