### PR TITLE
consider currently specified schema when getting column info

### DIFF
--- a/lib/queryBuilder/InternalOptions.js
+++ b/lib/queryBuilder/InternalOptions.js
@@ -6,6 +6,7 @@ class InternalOptions {
     this.keepImplicitJoinProps = false;
     this.isInternalQuery = false;
     this.debug = false;
+    this.schema = undefined;
   }
 
   clone() {
@@ -15,6 +16,7 @@ class InternalOptions {
     copy.keepImplicitJoinProps = this.keepImplicitJoinProps;
     copy.isInternalQuery = this.isInternalQuery;
     copy.debug = this.debug;
+    copy.schema = this.schema;
 
     return copy;
   }

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -844,8 +844,11 @@ class QueryBuilder extends QueryBuilderBase {
     const knex = this.knex();
     const tableParts = table.split('.');
     const columnInfoQuery = knex(last(tableParts)).columnInfo();
+    const schema = this.internalOptions().schema;
 
-    if (tableParts.length > 1) {
+    if (schema) {
+      columnInfoQuery.withSchema(schema);
+    } else if (tableParts.length > 1) {
       columnInfoQuery.withSchema(tableParts[0]);
     }
 
@@ -857,6 +860,7 @@ class QueryBuilder extends QueryBuilderBase {
   }
 
   withSchema(schema) {
+    this.internalOptions().schema = schema;
     this.internalContext().onBuild.push(builder => {
       if (!builder.has(/withSchema/)) {
         // Need to push this operation to the front because knex doesn't use the


### PR DESCRIPTION
I brought the issue that this addresses up over in gitter - the short version is that when getting column metadata, the currently specified schema is not considered and passed on to the column info query.

The only way I could find to make this happen was to track the current schema in `internalOptions`. Other recommendations for a way to make this happen are welcome. 