### PR TITLE
fix typo in query examples

### DIFF
--- a/doc/guide/query-examples.md
+++ b/doc/guide/query-examples.md
@@ -136,7 +136,7 @@ Objection allows a bit more modern syntax with groupings and subqueries. Where k
 
 ```js
 const nonMiddleAgedJennifers = await Person.query()
-  .where(builder => builder.where('age', '<', 4).orWhere('age', '>', 60))
+  .where(builder => builder.where('age', '<', 40).orWhere('age', '>', 60))
   .where('firstName', 'Jennifer')
   .orderBy('lastName');
 


### PR DESCRIPTION
Fixes code to match the query shown in the docs below:

```sql
select "persons".* from "persons"
where ("age" < 40 or "age" > 60)
and "firstName" = 'Jennifer'
order by "lastName" asc
```
