### PR TITLE
Add InsertAndFetchOperation#models

### DIFF
--- a/lib/queryBuilder/operations/InsertAndFetchOperation.js
+++ b/lib/queryBuilder/operations/InsertAndFetchOperation.js
@@ -14,6 +14,10 @@ class InsertAndFetchOperation extends DelegateOperation {
     }
   }
 
+  get models() {
+    return this.delegate.models;
+  }
+
   async onAfter2(builder, inserted) {
     const modelClass = builder.modelClass();
     const insertedModels = await super.onAfter2(builder, inserted);

--- a/tests/integration/staticHooks.js
+++ b/tests/integration/staticHooks.js
@@ -2512,7 +2512,7 @@ module.exports = session => {
             });
         });
 
-        it('should have access to `inputItems`', () => {
+        it('should have access to `inputItems`', async () => {
           Movie.beforeInsert = createHookSpy(({ inputItems }) => {
             expect(inputItems.length).to.equal(1);
             expect(inputItems[0] instanceof Movie).to.equal(true);
@@ -2523,11 +2523,9 @@ module.exports = session => {
             ]);
           });
 
-          return Movie.query()
-            .insert({ name: 'Inserted' })
-            .then(() => {
-              expect(Movie.beforeInsert.calls.length).to.equal(1);
-            });
+          await Movie.query().insert({ name: 'Inserted' });
+          await Movie.query().insertAndFetch({ name: 'Inserted' });
+          expect(Movie.beforeInsert.calls.length).to.equal(2);
         });
 
         it('should be able to fetch the rows about to be updated', () => {


### PR DESCRIPTION
So that the beforeInsert() and afterInsert() static query hooks return correct model-data in inputItems when using insertAndFetch()

* Includes tests

Closes #1839