### PR TITLE
Fix: Objection iterated over every byte of Buffer properties

### DIFF
--- a/lib/model/graph/ModelGraphBuilder.js
+++ b/lib/model/graph/ModelGraphBuilder.js
@@ -183,7 +183,7 @@ function forEachPropertyReference(obj, callback) {
 function visitStrings(value, path, visit) {
   if (Array.isArray(value)) {
     visitStringsInArray(value, path, visit);
-  } else if (isObject(value) && !(value instanceof Buffer)) {
+  } else if (isObject(value) && !Buffer.isBuffer(value)) {
     visitStringsInObject(value, path, visit);
   } else if (isString(value)) {
     visit(value, path);

--- a/lib/model/graph/ModelGraphBuilder.js
+++ b/lib/model/graph/ModelGraphBuilder.js
@@ -183,7 +183,7 @@ function forEachPropertyReference(obj, callback) {
 function visitStrings(value, path, visit) {
   if (Array.isArray(value)) {
     visitStringsInArray(value, path, visit);
-  } else if (isObject(value)) {
+  } else if (isObject(value) && !(value instanceof Buffer)) {
     visitStringsInObject(value, path, visit);
   } else if (isString(value)) {
     visit(value, path);


### PR DESCRIPTION
I noticed huuuge response times when saving models that contain a binary Buffer.

The profiler showed that Objection was burning seconds iterating over every byte of the binary property, pushing and poping its indices, while trying to find a graph string in those bytes.

This PR fixes that particular problem, but there might be other, similar issues since `isObject` casts a _very_ wide net in JS.