### PR TITLE
Add missing type declaration for $afterFind instance hook

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1677,6 +1677,7 @@ declare namespace Objection {
     $afterUpdate(opt: ModelOptions, queryContext: QueryContext): Promise<any> | void;
     $beforeUpdate(opt: ModelOptions, queryContext: QueryContext): Promise<any> | void;
     $afterGet(queryContext: QueryContext): Promise<any> | void;
+    $afterFind(queryContext: QueryContext): Promise<any> | void;
     $beforeDelete(queryContext: QueryContext): Promise<any> | void;
     $afterDelete(queryContext: QueryContext): Promise<any> | void;
 


### PR DESCRIPTION
A simple fix to add a type for $afterFind instance method. There is one for $afterGet but that is deprecated.

I can create an issue if necessary but wasn't sure such a small change required an issue.