### PR TITLE
chore(typings): Typecheck WhereMethod object

### DIFF
--- a/tests/ts/query-builder-api/find-methods.ts
+++ b/tests/ts/query-builder-api/find-methods.ts
@@ -19,6 +19,12 @@ import { Person } from '../fixtures/person';
     firstName: 'Jennifer',
     lastName: 'Lawrence'
   });
+  await Person.query().findOne({
+    firstName: 'Jennifer',
+    lastName: 'Lawrence',
+    // @ts-expect-error
+    DOESNT_EXIST: 'none'
+  });
   await Person.query().findOne('age', '>', 20);
   await Person.query().findOne(raw('random() < 0.5'));
 
@@ -101,7 +107,7 @@ import { Person } from '../fixtures/person';
     .where(function() {
       this.where('id', 1).orWhere('id', '>', 10);
     })
-    .orWhere({ name: 'Tester' });
+    .orWhere({ lastName: 'Tester' });
   await Person.query().where('firstName', 'like', '%mark%');
   await Person.query().where('votes', '>', 100);
   let subquery = Person.query()
@@ -112,7 +118,7 @@ import { Person } from '../fixtures/person';
   await Person.query().where('id', 'in', subquery);
   await Person.query()
     .where('id', 1)
-    .orWhere({ votes: 100, user: 'knex' });
+    .orWhere({ age: 100, oldLastName: 'knex' });
 
   await Person.query()
     .whereNot({
@@ -125,7 +131,7 @@ import { Person } from '../fixtures/person';
     .whereNot(function() {
       this.where('id', 1).orWhereNot('id', '>', 10);
     })
-    .orWhereNot({ name: 'Tester' });
+    .orWhereNot({ lastName: 'Tester' });
   await Person.query().whereNot('votes', '>', 100);
   subquery = Person.query()
     .whereNot('votes', '>', 100)

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -371,10 +371,6 @@ declare namespace Objection {
     <QBA extends AnyQueryBuilder>(qb: QBA): QB;
 
     (obj: PartialModelObject<ModelType<QB>>): QB;
-    // We must allow any keys in the object. The previous type
-    // is kind of useless, but maybe one day vscode and other
-    // tools can autocomplete using it.
-    (obj: object): QB;
   }
 
   interface WhereRawMethod<QB extends AnyQueryBuilder> extends RawInterface<QB> {}


### PR DESCRIPTION
When in TypeScript, querying doesn't check the object of `Where` clauses. Removing the broad type (`(obj: object) => QB)`) ensures that TypeScript does the type checking.

Added to the find-methods with a [`// @ts-expect-error` ](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments) compiler directive to ensure that it is invalid.

**Impact:** For repos with incorrect properties referenced, this will change to now show up as compiler errors (which is the desired effect).

The additional change on l104 is a perfect example of what is actually caught with this type change.
```diff
// Errors since 'name' doesn't exist on 'Person'
- .orWhere({ name: 'Tester' });
+ .orWhere({ lastName: 'Tester' });
```

### Notes / Additional

- Currently Travis doesn't appear to run typescript, could be added (happy to submit a PR to do this) to type check.
<br />I'm not a Travis expert, but something like:
  ```diff
  // package.json
  "scripts": {
  + "build-travis": "npm run tsc --noEmit"
  ```
  ```diff .travis.yml
  # .travis.yml
  script:
  + - npm run-script build-travis
  - npm run-script test-travis
  ```

- This doesn't affect tests since it is a typing change only.
- This only affects the single function whose signature was changed (when passing an object). Subsequent draft PR coming with a proposal for other methods.