### PR TITLE
Add missing argument types in QueryBuilder's for

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1006,7 +1006,7 @@ declare namespace Objection {
     ): NumberQueryBuilder<this>;
 
     unrelate(): NumberQueryBuilder<this>;
-    for(ids: ForIdValue | ForIdValue[]): this;
+    for<MF extends Model>(ids: ForIdValue | ForIdValue[] | QueryBuilder<MF, any> | MF | Array<MF>): this;
 
     withGraphFetched(expr: RelationExpression<M>, options?: GraphOptions): this;
     withGraphJoined(expr: RelationExpression<M>, options?: GraphOptions): this;


### PR DESCRIPTION
This PR addresses the missing QueryBuilder, model instances and array of model instances types in the argument of QueryBuilder's `for` method. Because as per documentation, it should be as such:

---

This method takes one argument (the owner(s) of the relation) and it can have any of the following types:

* A single identifier (can be composite)
* An array of identifiers (can be composite)
* A QueryBuilder
* A model instance.
* An array of model instances.