### PR TITLE
Fix RelationOwner._getPropsFromModels

### DIFF
--- a/lib/relations/RelationOwner.js
+++ b/lib/relations/RelationOwner.js
@@ -219,7 +219,7 @@ function containsNonNull(arr) {
 }
 
 function join(id) {
-  return id.join(',');
+  return id.map(x => (Buffer.isBuffer(x) ? x.toString('hex') : x)).join(',');
 }
 
 function isIdProp(relationProp) {

--- a/tests/integration/misc/#1627.js
+++ b/tests/integration/misc/#1627.js
@@ -90,5 +90,21 @@ module.exports = session => {
 
       expect(result).to.eql(inserted);
     });
+    it('should fetch multiple relations correctly', async () => {
+      const ids = [
+        Buffer.from('00000000000000000000000000007AAC', 'hex'),
+        Buffer.from('00000000000000000000000000007AAD', 'hex'),
+        Buffer.from('00000000000000000000000000007AAE', 'hex')
+      ];
+      const graph = ids.map(id => ({
+        id,
+        roles: [{ id: crypto.randomBytes(16) }]
+      }));
+      const inserted = await User.query().insertGraph(graph);
+      const result = await User.query()
+        .findByIds(ids)
+        .withGraphFetched('roles');
+      expect(result).to.eql(inserted);
+    });
   });
 };

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -435,7 +435,8 @@ describe('utils', () => {
       [Buffer.from('00000000000000000000000000007AAC', 'hex')]
     ];
     it('should work with Buffer items', () => {
-      expect(uniqBy(items)).to.eql(items);
+      const itemsForTest = items.map(([value]) => value);
+      expect(uniqBy(itemsForTest)).to.eql(itemsForTest);
     });
     it('should work with Buffer[] items', () => {
       expect(uniqBy(items)).to.eql(items);

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -12,7 +12,7 @@ const {
 const { range } = require('lodash');
 const { compose, mixin } = require('../../lib/utils/mixin');
 const { map } = require('../../lib/utils/promiseUtils');
-const { jsonEquals } = require('../../lib/utils/objectUtils');
+const { jsonEquals, uniqBy } = require('../../lib/utils/objectUtils');
 
 describe('utils', () => {
   describe('mixin', () => {
@@ -426,6 +426,24 @@ describe('utils', () => {
           ]
         )
       ).to.equal(false);
+    });
+  });
+  describe('uniqBy', () => {
+    const items = [
+      [Buffer.from('00000000000000000000000000007AAD', 'hex')],
+      [Buffer.from('00000000000000000000000000007AAE', 'hex')],
+      [Buffer.from('00000000000000000000000000007AAC', 'hex')]
+    ];
+    it('should work with Buffer items', () => {
+      expect(uniqBy(items)).to.eql(items);
+    });
+    it('should work with Buffer[] items', () => {
+      expect(uniqBy(items)).to.eql(items);
+    });
+    it('should work with Buffer[] items with custom keyGetter function', () => {
+      expect(
+        uniqBy(items, item => item.map(x => (Buffer.isBuffer(x) ? x.toString('hex') : x)).join(','))
+      ).to.eql(items);
     });
   });
 });


### PR DESCRIPTION
It would drop some unique props in case if they had buffer values.
As the result some related models won't be fetched.
This commit fixes the join function, which converts buffers to generate correct key for the prop.