### PR TITLE
Typings: Match $knex() arguments to static knex()

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1707,7 +1707,7 @@ declare namespace Objection {
     $traverseAsync(filterConstructor: typeof Model, traverser: TraverserFunction): Promise<this>;
     $traverseAsync(traverser: TraverserFunction): Promise<this>;
 
-    $knex(): Knex;
+    $knex(knex?: Knex): Knex;
     $transaction(): Knex;
 
     QueryBuilderType: QueryBuilder<this, this[]>;


### PR DESCRIPTION
Adds the optional knex argument to the instance method to match the static equivalent, as implied by https://vincit.github.io/objection.js/api/model/instance-methods.html#knex