### PR TITLE
added error for relatedQueries ommiting 'for' outside subqueries

### DIFF
--- a/lib/relations/RelationOwner.js
+++ b/lib/relations/RelationOwner.js
@@ -190,7 +190,10 @@ function isQueryBuilder(item) {
 
 function findFirstNonPartialAncestorQuery(builder) {
   builder = builder.parentQuery();
-
+  if (!builder)
+    throw Error(
+      'query method `for` ommitted outside a subquery, can not figure out relation target'
+    );
   while (builder.isPartial()) {
     if (!builder.parentQuery()) {
       break;

--- a/tests/integration/misc/relatedQueryErrors.js
+++ b/tests/integration/misc/relatedQueryErrors.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const { Model } = require('../../../');
+
+module.exports = session => {
+  describe('model relatedQueries fail when they lack a proper target', () => {
+    let knex = session.knex;
+
+    class Post extends Model {
+      static get tableName() {
+        return 'posts';
+      }
+    }
+
+    class User extends Model {
+      static get tableName() {
+        return 'users';
+      }
+      static get relationMappings() {
+        return {
+          posts: {
+            modelClass: Post,
+            relation: Model.HasManyRelation,
+            join: {
+              from: 'users.id',
+              to: 'posts.user_id'
+            }
+          }
+        };
+      }
+    }
+
+    before(async () => {
+      const knex = session.knex;
+
+      await knex.schema.dropTableIfExists('posts');
+      await knex.schema.dropTableIfExists('users');
+
+      await knex.schema
+        .createTable('users', table => {
+          table.increments('id').primary();
+          table.string('name');
+        })
+        .createTable('posts', table => {
+          table.increments('id').primary();
+          table
+            .integer('user_id')
+            .unsigned()
+            .references('id')
+            .inTable('users');
+          table.string('content');
+        });
+    });
+
+    after(async () => {
+      await knex.schema.dropTableIfExists('posts');
+      await knex.schema.dropTableIfExists('users');
+    });
+
+    it('relatedQuery insert does not silently fail when ommiting `for` a target', async () => {
+      try {
+        await User.relatedQuery('posts', knex).insert({ content: 'my post content' });
+      } catch (e) {
+        expect(e.message).to.equal(
+          'query method `for` ommitted outside a subquery, can not figure out relation target'
+        );
+      }
+    });
+    it('relatedQuery where fails when `for` is ommited and is not a subquery', async () => {
+      try {
+        await User.relatedQuery('posts', knex).where({ content: 'my post content' });
+      } catch (e) {
+        expect(e.message).to.equal(
+          'query method `for` ommitted outside a subquery, can not figure out relation target'
+        );
+      }
+    });
+  });
+};


### PR DESCRIPTION
Hello, recently I came across a weird issue where an insert statement was failing silently, that insert was using `relatedQuery` without `for`, so I went through some digging, I found that the foreign key is overridden even if it was included in the insert. through some other digging, I found that lacking .for outside other non-subqueries could result in a not so obvious error, like the one in #1466,

Originally, I thought these were two problems, so I had placed two if statements to check if a target exists or not, one in RelationInsertOperation.js, and the other in RelationOwner.js, and I wrote a quick test, and as I found out, the check in the RelationOwner constructor was able to catch both error conditions, and what I deduced was:

`findFirstNonPartialAncestorQuery` keeps looking for the first non-partial parent query, my condition checks if that parent even exists, let alone isPartial or not. partial queries that lack a parent at all would never pass this function. this is what causes #1466 in `where` queries, but the curious thing is that `insert` statements do not error out here, yet my if statement catches it, I'm not really sure why. If you have a hint as to why I can dig deeper but as this is my first time peeking into Objection's internal I kept my journey short today.

As is though, this doesn't seem to break any other previous tests, and catches my two error conditions.