### PR TITLE
feat(knex): add onConflict/ignore/merge for upserts

### DIFF
--- a/doc/api/query-builder/mutate-methods.md
+++ b/doc/api/query-builder/mutate-methods.md
@@ -829,3 +829,33 @@ See [knex documentation](http://knexjs.org/#Builder-truncate)
 | Type                                | Description                        |
 | ----------------------------------- | ---------------------------------- |
 | [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## onConflict()
+
+See [knex documentation](http://knexjs.org/#Builder-onConflict)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## ignore()
+
+See [knex documentation](http://knexjs.org/#Builder-ignore)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## merge()
+
+See [knex documentation](http://knexjs.org/#Builder-merge)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |

--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -683,6 +683,18 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
   orWhereNotColumn(...args) {
     return this.addOperation(new KnexOperation('orWhereNotColumn'), args);
   }
+
+  onConflict(...args) {
+    return this.addOperation(new KnexOperation('onConflict'), args);
+  }
+
+  ignore(...args) {
+    return this.addOperation(new KnexOperation('ignore'), args);
+  }
+
+  merge(...args) {
+    return this.addOperation(new KnexOperation('merge'), args);
+  }
 }
 
 Object.defineProperties(QueryBuilderBase.prototype, {


### PR DESCRIPTION
Knex has recently released means to do upserts via ON CONFLICT clauses. I was
able to test it and it works well.

related to: #446 #192 #1406

About this PR: first time here, unsure where and how to add tests though

knex documentation: http://knexjs.org/#Builder-onConflict