### PR TITLE
Fix migration broken url on changelog

### DIFF
--- a/doc/release-notes/changelog.md
+++ b/doc/release-notes/changelog.md
@@ -148,7 +148,7 @@
 
 ### Breaking changes
 
-See the [migration guide](/1.x/migration.md).
+See the [migration guide](/release-notes/migration.md).
 
 ## 1.6.10
 


### PR DESCRIPTION
Hi, I just saw that the migration guide link on the changelog is
broken, replaced it with a new one.