### PR TITLE
Update knex devDependency to 0.21.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "knex": "0.x"
   },
   "devDependencies": {
-    "@types/node": "^14.14.13",
+    "@types/node": "^14.14.16",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
     "coveralls": "^3.1.0",
@@ -79,7 +79,7 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "husky": "^4.3.6",
-    "knex": "0.21.6",
+    "knex": "0.21.15",
     "lint-staged": "^10.5.3",
     "mocha": "^8.2.1",
     "mysql": "^2.18.1",


### PR DESCRIPTION
This is likely to be the last version in 0.21 branch (unless we'll be forced to do hotfixes), so it makes sense to bump.