### PR TITLE
Fix a misleading code example for returning tricks

### DIFF
--- a/doc/recipes/returning-tricks.md
+++ b/doc/recipes/returning-tricks.md
@@ -21,7 +21,8 @@ Update a single row by ID and return the updated Model instance in 1 query:
 const jennifer = await Person.query()
   .patch({ firstName: 'Jenn', lastName: 'Lawrence' })
   .where('id', 1234)
-  .returning('*');
+  .returning('*')
+  .first();
 
 console.log(jennifer.updatedAt); // NOW()-ish
 console.log(jennifer.firstName); // "Jenn"


### PR DESCRIPTION
# Summary 
* The example in docs is a incorrect: `.patch(...)` with `.returning('*')` will update multiple rows, result will be an array
* Added `.first()` to showcase a nice chainable API (an alternative would be array restructuring) 

P.S
Thanks, guys for the awesome project 😸 