### PR TITLE
Add failing test for `hasWheres` for `withGraphJoined` query

### DIFF
--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -1093,6 +1093,8 @@ describe('QueryBuilder', () => {
     expect(TestModel.query().update({}).hasWheres()).to.equal(false);
     expect(TestModel.query().patch({}).hasWheres()).to.equal(false);
     expect(TestModel.query().delete().hasWheres()).to.equal(false);
+    expect(TestModel.query().withGraphJoined('belongsToOneRelation').hasWheres()).to.equal(false);
+    expect(TestModel.query().withGraphFetched('belongsToOneRelation').hasWheres()).to.equal(false);
 
     const wheres = [
       'findOne',


### PR DESCRIPTION
The new implementation of `hasWheres` in https://github.com/Vincit/objection.js/commit/4e695cfcc4aff31e35d4c1bb6aecefbe5207501f throws an error when a query includes `withGraphJoined`. A query including `withGraphFetched` succeeds. I'm hoping @koskimas you're able to get to this first, since it will probably be a while before I'm able to prioritize the fix. Please feel free to take this branch over 🙏 

![image](https://user-images.githubusercontent.com/5565407/105562179-162d0680-5cce-11eb-8d92-faf821a9b21e.png)

[Gitter conversation](https://gitter.im/Vincit/objection.js?at=600b5f713855dd07fd70e352)