### PR TITLE
Fix #1954 fix graphOptions typings

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -752,8 +752,8 @@ declare namespace Objection {
   export interface GraphOptions {
     minimize?: boolean;
     separator?: string;
-    aliases?: string[];
-    joinOperation: string;
+    aliases?: {[key: string]: string};
+    joinOperation?: string;
     maxBatchSize?: number;
   }
 


### PR DESCRIPTION
Update typescript definitions for GraphOptions, the previous type definitions are now incorrect.

Aliases should be an object and joinOperation should be optional.