### PR TITLE
Add from method to ReferenceBuilder interface

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -58,7 +58,9 @@ declare namespace Objection {
     ): ValueBuilder;
   }
 
-  export interface ReferenceBuilder extends Castable {}
+  export interface ReferenceBuilder extends Castable {
+    from(tableReference: string): this;
+  }
   export interface ReferenceFunction {
     (expression: string): ReferenceBuilder;
   }


### PR DESCRIPTION
This PR only adds the `from` method to the `ReferenceBuilder` type since right now is missing.