### PR TITLE
Remove redundant TODO.

### DIFF
--- a/tests/unit/queryBuilder/RelationExpression.js
+++ b/tests/unit/queryBuilder/RelationExpression.js
@@ -878,9 +878,6 @@ describe('RelationExpression', () => {
       testParseFail('a asb');
       testParseFail('aas b');
       testParseFail('a asd b');
-      // TODO: enable for v2.0.
-      // testParseFail('[a.b, a.c]');
-      // testParseFail('a.[b.c, b.d]');
     });
 
     it('should accept single function or modifier name in $modifiers', () => {


### PR DESCRIPTION
While attempting to develop a fix for #1684 I've noticed a comment that was meant to be implemented once v2 was released. It appears to be redundant now that the functionality of having multiple relations loaded as a graph has been implemented. 