### PR TITLE
identify internal Knex objects by properties other than constructor name

### DIFF
--- a/lib/utils/knexUtils.js
+++ b/lib/utils/knexUtils.js
@@ -37,25 +37,29 @@ function isMsSql(knex) {
 }
 
 function isKnexQueryBuilder(value) {
-  return hasConstructor(value, 'Builder') && 'client' in value;
+  return (
+    hasConstructor(value) &&
+    isFunction(value.select) &&
+    isFunction(value.column) &&
+    value.select === value.column &&
+    'client' in value
+  );
 }
 
 function isKnexJoinBuilder(value) {
-  return hasConstructor(value, 'JoinClause') && 'joinType' in value;
+  return hasConstructor(value) && value.grouping === 'join' && 'joinType' in value;
 }
 
 function isKnexRaw(value) {
-  return hasConstructor(value, 'Raw') && 'client' in value;
+  return hasConstructor(value) && value.isRawInstance && 'client' in value;
 }
 
 function isKnexTransaction(knex) {
   return !!getDialect(knex) && isFunction(knex.commit) && isFunction(knex.rollback);
 }
 
-function hasConstructor(value, constructorName) {
-  return (
-    isObject(value) && isFunction(value.constructor) && value.constructor.name === constructorName
-  );
+function hasConstructor(value) {
+  return isObject(value) && isFunction(value.constructor);
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes #2123 

Identify internal Knex objects using properties other than the constructor name, which when used in a string literal fails to match after the code has been minified (which renames the class to something shorter).
