### PR TITLE
Update find-methods.md

### DIFF
--- a/doc/api/query-builder/find-methods.md
+++ b/doc/api/query-builder/find-methods.md
@@ -703,6 +703,17 @@ See [knex documentation](http://knexjs.org/#Builder-unionAll)
 | ----------------------------------- | ---------------------------------- |
 | [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
 
+## intersect()
+
+See [knex documentation](http://knexjs.org/#Builder-unionAll)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+
 ## having()
 
 See [knex documentation](http://knexjs.org/#Builder-having)


### PR DESCRIPTION
Adds a stub documentation for the QueryBuilder intersect method from knex, redirecting to knex documentation.

Note : The link is currently slightly wrong (hyperlinking to #Builder-unionAll instead of #intersect) because the knex doc doesn't have a hyperlink to intersect. This seems better than nothing. 