### PR TITLE
Add additional check for modelClass.prototype in getReadOnlyAttribute…

### DIFF
--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -858,8 +858,8 @@ function getReadOnlyAttributes(modelClass) {
 }
 
 function getReadOnlyAttributesRecursively(modelClass) {
-  if (modelClass === Model) {
-    // Stop recursion to the model class.
+  if (modelClass === Model || modelClass.prototype == undefined) {
+    // Stop recursion to the model class or its prototype is null or undefined.
     return [];
   }
 


### PR DESCRIPTION
See issue: https://github.com/Vincit/objection.js/issues/2150

When using ts-mixer in typescript, it may result in modelClass.protoype = undefined, which caused exception. Add additional check here should be safe. 