### PR TITLE
Fix issues #2158 and #1649

### DIFF
--- a/tests/ts/query-examples/returning-queries.ts
+++ b/tests/ts/query-examples/returning-queries.ts
@@ -1,0 +1,12 @@
+import { Person } from '../fixtures/person';
+
+(async () => {
+  let jennifer = await Person.query().findById(1);
+
+  const updateJennifer = await jennifer!
+    .$query()
+    .patch({ firstName: 'J.', lastName: 'Lawrence' })
+    .returning('*');
+
+  console.log(updateJennifer.firstName);
+})();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -320,6 +320,14 @@ declare namespace Objection {
   type NumberQueryBuilder<T extends { NumberQueryBuilderType: any }> = T['NumberQueryBuilderType'];
 
   /**
+   * This is basically the number query builder but we know the number would always be one
+   * and if this was converted to an array (via returning('*')), the JS would return a single
+   * item instead of an array.
+   */
+  type OneQueryBuilder<T extends { OneQueryBuilderType: any }> =
+    T['OneQueryBuilderType'];
+
+  /**
    * Gets the page query builder type for a query builder.
    */
   type PageQueryBuilder<T extends { PageQueryBuilderType: any }> = T['PageQueryBuilderType'];
@@ -625,6 +633,8 @@ declare namespace Objection {
       column: string | string[]
     ): QB extends ArrayQueryBuilder<QB>
       ? ArrayQueryBuilder<QB>
+      : QB extends OneQueryBuilder<QB>
+      ? SingleQueryBuilder<QB>
       : QB extends NumberQueryBuilder<QB>
       ? ArrayQueryBuilder<QB>
       : SingleQueryBuilder<QB>;
@@ -934,16 +944,28 @@ declare namespace Objection {
     castTo<MC extends Model>(modelClass: ModelConstructor<MC>): QueryBuilderType<MC>;
     castTo<R>(): QueryBuilder<M, R>;
 
-    update(update: PartialModelObject<M>): NumberQueryBuilder<this>;
-    update(): NumberQueryBuilder<this>;
+    update(
+      update: PartialModelObject<M>
+    ): this extends SingleQueryBuilder<this>
+      ? OneQueryBuilder<this>
+      : NumberQueryBuilder<this>;
+    update(): this extends SingleQueryBuilder<this>
+      ? OneQueryBuilder<this>
+      : NumberQueryBuilder<this>;
     updateAndFetch(update: PartialModelObject<M>): SingleQueryBuilder<this>;
     updateAndFetchById(
       id: MaybeCompositeId,
       update: PartialModelObject<M>
     ): SingleQueryBuilder<this>;
 
-    patch(update: PartialModelObject<M>): NumberQueryBuilder<this>;
-    patch(): NumberQueryBuilder<this>;
+    patch(
+      update: PartialModelObject<M>
+    ): this extends SingleQueryBuilder<this>
+      ? OneQueryBuilder<this>
+      : NumberQueryBuilder<this>;
+    patch(): this extends SingleQueryBuilder<this>
+      ? OneQueryBuilder<this>
+      : NumberQueryBuilder<this>;
     patchAndFetch(update: PartialModelObject<M>): SingleQueryBuilder<this>;
     patchAndFetchById(
       id: MaybeCompositeId,
@@ -1064,6 +1086,7 @@ declare namespace Objection {
     SingleQueryBuilderType: QueryBuilder<M, M>;
     MaybeSingleQueryBuilderType: QueryBuilder<M, M | undefined>;
     NumberQueryBuilderType: QueryBuilder<M, number>;
+    OneQueryBuilderType: QueryBuilder<M, 1>;
     PageQueryBuilderType: QueryBuilder<M, Page<M>>;
 
     then<R1 = R, R2 = never>(

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -324,8 +324,7 @@ declare namespace Objection {
    * and if this was converted to an array (via returning('*')), the JS would return a single
    * item instead of an array.
    */
-  type OneQueryBuilder<T extends { OneQueryBuilderType: any }> =
-    T['OneQueryBuilderType'];
+  type OneQueryBuilder<T extends { OneQueryBuilderType: any }> = T['OneQueryBuilderType'];
 
   /**
    * Gets the page query builder type for a query builder.
@@ -946,9 +945,7 @@ declare namespace Objection {
 
     update(
       update: PartialModelObject<M>
-    ): this extends SingleQueryBuilder<this>
-      ? OneQueryBuilder<this>
-      : NumberQueryBuilder<this>;
+    ): this extends SingleQueryBuilder<this> ? OneQueryBuilder<this> : NumberQueryBuilder<this>;
     update(): this extends SingleQueryBuilder<this>
       ? OneQueryBuilder<this>
       : NumberQueryBuilder<this>;
@@ -960,9 +957,7 @@ declare namespace Objection {
 
     patch(
       update: PartialModelObject<M>
-    ): this extends SingleQueryBuilder<this>
-      ? OneQueryBuilder<this>
-      : NumberQueryBuilder<this>;
+    ): this extends SingleQueryBuilder<this> ? OneQueryBuilder<this> : NumberQueryBuilder<this>;
     patch(): this extends SingleQueryBuilder<this>
       ? OneQueryBuilder<this>
       : NumberQueryBuilder<this>;


### PR DESCRIPTION
I gave issues #2158 and #1649 a shot to see if I could fix them.

My approach was:
- If patch/update are running on a SingleQueryBuilder, return a new kind of query builder called OneQueryBuilder instead of NumberQueryBuilder. OneQueryBuilder is simply QueryBuilder<M, 1>
- In `ReturningMethod`, if QB extends OneQueryBuilder, return SingleQueryBuilder<QB>.

It worked! I added a small test as well to confirm. Not sure if there are any corner cases I forgot about...