### PR TITLE
Fix insert graph method typing

### DIFF
--- a/tests/ts/model/model-inheritance.ts
+++ b/tests/ts/model/model-inheritance.ts
@@ -1,0 +1,9 @@
+import { Animal } from '../fixtures/animal';
+
+export class Dog extends Animal {
+  species!: 'Canis familiaris';
+}
+
+export function isDog(animal: Animal): animal is Dog {
+  return animal.species === 'Canis familiaris';
+}

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -687,15 +687,15 @@ declare namespace Objection {
   interface InsertGraphMethod<M extends Model> {
     <QB extends AnyQueryBuilder>(
       this: QB,
-      graph: PartialModelGraph<M>,
-      options?: InsertGraphOptions
-    ): SingleQueryBuilder<QB>;
-
-    <QB extends AnyQueryBuilder>(
-      this: QB,
       graph: PartialModelGraph<M>[],
       options?: InsertGraphOptions
     ): ArrayQueryBuilder<QB>;
+
+    <QB extends AnyQueryBuilder>(
+      this: QB,
+      graph: PartialModelGraph<M>,
+      options?: InsertGraphOptions
+    ): SingleQueryBuilder<QB>;
   }
 
   export interface UpsertGraphOptions {


### PR DESCRIPTION
Previously, the SingleQueryBuilder definition went first, so even if an array was passed as `graph`, it would be typed as SingleQueryBuilder. This created all sorts of weird effects, like making it impossible to write a type predicate on a model subclass.

This commit reorders it so it tries to type it as ArrayQueryBuilder first. It also adds a test to make sure that model subclasses work correctly.