### PR TITLE
fix: jsonSchemaWithoutRequired doesn't handle empty definitions

### DIFF
--- a/lib/model/AjvValidator.js
+++ b/lib/model/AjvValidator.js
@@ -256,7 +256,7 @@ function jsonSchemaWithoutRequired(jsonSchema) {
   return Object.assign(
     omit(jsonSchema, ['required', ...subSchemaProps]),
     ...subSchemaProps.map((prop) => subSchemaWithoutRequired(jsonSchema, prop)),
-    jsonSchema && jsonSchema.definitions
+    jsonSchema && jsonSchema.definitions && Object.keys(jsonSchema.definitions).length > 0
       ? {
           definitions: Object.assign(
             ...Object.keys(jsonSchema.definitions).map((prop) => ({

--- a/tests/unit/model/AjvValidator.js
+++ b/tests/unit/model/AjvValidator.js
@@ -42,5 +42,23 @@ describe('AjvValidator', () => {
       expect(definitions.length).to.be(2);
       definitions.forEach((d) => expect(d.required).to.be(undefined));
     });
+
+    it('should handle empty definitions', () => {
+      const emptyDefinitionsSchema = {
+        type: 'object',
+        required: ['a'],
+        definitions: {},
+        additionalProperties: false,
+        properties: {
+          a: { type: 'string' },
+        },
+      };
+      const validator = new AjvValidator({ onCreateAjv: () => {} });
+      validator.getValidator(
+        modelClass('test', emptyDefinitionsSchema),
+        emptyDefinitionsSchema,
+        true
+      );
+    });
   });
 });


### PR DESCRIPTION
A schema with an empty definitions object causes `jsonSchemaWithoutRequired` to throw

```
 TypeError: Cannot convert undefined or null to object
      at Function.assign (<anonymous>)
      at jsonSchemaWithoutRequired (lib/model/AjvValidator.js:262:20)
      at AjvValidator.compilePatchValidator (lib/model/AjvValidator.js:136:18)
      at AjvValidator.getValidator (lib/model/AjvValidator.js:120:26)
```