### PR TITLE
fixes #2190

### DIFF
--- a/tests/ts/query-examples/basic-queries/insert.ts
+++ b/tests/ts/query-examples/basic-queries/insert.ts
@@ -1,4 +1,11 @@
 import { Person } from '../../fixtures/person';
+import { Animal } from '../../fixtures/animal';
+
+type IPerson = Partial<
+  Pick<Person, 'id' | 'firstName' | 'lastName'> & {
+    pets: Partial<Pick<Animal, 'id' | 'name'>>[];
+  }
+>;
 
 (async () => {
   const jennifer = await Person.query().insert({
@@ -9,4 +16,10 @@ import { Person } from '../../fixtures/person';
   const personPromise: PromiseLike<Person> = Person.fromJson({ firstName: 'Jennifer' })
     .$query()
     .insert();
+
+  const jenniferObj: IPerson = {
+    firstName: 'Jennifer',
+    lastName: 'Lawrence',
+  };
+  await Person.query().insert(jenniferObj);
 })();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -201,10 +201,10 @@ declare namespace Objection {
    */
   type PartialModelObject<T extends Model> = {
     [K in DataPropertyNames<T>]?: Defined<T[K]> extends Model
-      ? T[K]
+      ? unknown
       : Defined<T[K]> extends Array<infer I>
       ? I extends Model
-        ? I[]
+        ? unknown[]
         : Expression<T[K]>
       : Expression<T[K]>;
   };


### PR DESCRIPTION
I don't think #2190 has been given enough attention. Granted, the title was misleading, but it included a particular use case which was failing.

Even though objection.js documentation doesn't cover separation of model classes and model data interfaces, I don't believe this is an edge case which doesn't deserve any support.

This PR fixes the typings for plain `insert` (not `insertGraph`) to accept model data interfaces and adds the regression test.
