### PR TITLE
Fix Ajv type in `onCreateAjv`

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1210,7 +1210,7 @@ declare namespace Objection {
   }
 
   export interface AjvConfig {
-    onCreateAjv(ajv: Ajv): void;
+    onCreateAjv(ajv: Ajv.Ajv): void;
     options?: AjvOptions;
   }
 


### PR DESCRIPTION
When trying to compile our project with TypeScript 4.5.5 we are receiving a build error in your lib.

```
node_modules/objection/typings/objection/index.d.ts:1213:22 - error TS2709: Cannot use namespace 'Ajv' as a type.

1213     onCreateAjv(ajv: Ajv): void;
```

The proposed change references the `Ajv` interface in the `Ajv` namespace, which is probably what you mean to do here?