### PR TITLE
fix aliasFor not working with join table in many-to-many relation

### DIFF
--- a/lib/queryBuilder/join/RelationJoiner.js
+++ b/lib/queryBuilder/join/RelationJoiner.js
@@ -126,7 +126,7 @@ class RelationJoiner {
 
       ownerTable: tableNode.parentNode.alias,
       relatedTableAlias: tableNode.alias,
-      joinTableAlias: tableNode.joinTableAlias,
+      joinTableAlias: tableNode.getJoinTableAlias(builder),
 
       relatedJoinSelectQuery: ensureIdAndRelationPropsAreSelected({
         builder: subqueryToJoin,
@@ -227,7 +227,7 @@ function getSelectionsForNode({ builder, tableNode, userSelectQueries }) {
     selections = mapUserSelectionsFromSubqueryToMainQuery({ userSelections, tableNode });
 
     if (userSelectedAllColumns && tableNode.relation.isObjectionManyToManyRelation) {
-      const extraSelections = getJoinTableExtraSelectionsForNode({ tableNode });
+      const extraSelections = getJoinTableExtraSelectionsForNode({ builder, tableNode });
       selections = selections.concat(extraSelections);
     }
   }
@@ -269,10 +269,10 @@ function mapUserSelectionsFromSubqueryToMainQuery({ userSelections, tableNode })
   });
 }
 
-function getJoinTableExtraSelectionsForNode({ tableNode }) {
+function getJoinTableExtraSelectionsForNode({ builder, tableNode }) {
   return tableNode.relation.joinTableExtras.map((extra) => {
     return new Selection(
-      tableNode.joinTableAlias,
+      tableNode.getJoinTableAlias(builder),
       extra.joinTableCol,
       tableNode.getColumnAliasForColumn(extra.aliasCol)
     );

--- a/lib/queryBuilder/join/TableNode.js
+++ b/lib/queryBuilder/join/TableNode.js
@@ -31,10 +31,6 @@ class TableNode {
     return this.expression.node.$name;
   }
 
-  get joinTableAlias() {
-    return this.modelClass.joinTableAlias(this.alias);
-  }
-
   getReferenceForColumn(column) {
     return `${this.alias}.${column}`;
   }
@@ -59,6 +55,17 @@ class TableNode {
 
   getIdFromFlatRow(flatRow) {
     return this.idGetter(flatRow);
+  }
+
+  getJoinTableAlias(builder) {
+    if (this.relation.isObjectionManyToManyRelation) {
+      return (
+        builder.aliasFor(this.relation.joinTableModelClass) ||
+        this.modelClass.joinTableAlias(this.alias)
+      );
+    } else {
+      return undefined;
+    }
   }
 
   _calculateAlias() {

--- a/tests/integration/find.js
+++ b/tests/integration/find.js
@@ -1753,6 +1753,19 @@ module.exports = (session) => {
           });
       });
 
+      it('should be able to alias the join table using aliasFor in many to many relation', () => {
+        return Model2.query()
+          .select('model2.*', 'model2Relation1.id')
+          .joinRelated('model2Relation1')
+          .aliasFor('Model1Model2', 'm1m2')
+          .where('m1m2.model1Id', '>', 5)
+          .then((models) => {
+            models = _.sortBy(models, ['idCol', 'id']);
+            expect(_.map(models, 'idCol')).to.eql([2, 2]);
+            expect(_.map(models, 'id')).to.eql([6, 7]);
+          });
+      });
+
       it('should be able to specify innerJoin', () => {
         return Model1.query()
           .innerJoinRelated('model1Relation1')


### PR DESCRIPTION
All tests pass.
This fixs https://github.com/Vincit/objection.js/issues/1957.

```
// This is an example from the docs. But if you call this, it would throw an error
// because the alias "pm" is not applied to the query.
await Person.query()
  .aliasFor('persons_movies', 'pm')
  .joinRelated('movies')
  .where('pm.someProp', 100);

```

In case of Many-to-Many relation, builder.joinRelated() uses tablenode.joinTableAlias to get the alias of the join table.
However tablenode.joinTableAlias does not check if an alias for jointable is set. tablenode.joinTableAlias always uses `${joinTableName}_join` as an alias.
so I make a new function "getJoinTableAlias()" which fix the alias problem and replace every "tablenode.joinTableAlias" with "tablenode.getJoinTableAlias()".

Also. I use and love objection.js.