### PR TITLE
Security Fix for Prototype Pollution in v1

### DIFF
--- a/lib/utils/objectUtils.js
+++ b/lib/utils/objectUtils.js
@@ -225,6 +225,9 @@ function set(obj, path, value) {
 
   for (let i = 0, l = path.length - 1; i < l; ++i) {
     const key = path[i];
+    if (key === '__proto__') {
+      return false;
+    }
     let child = obj[key];
 
     if (!isObject(child)) {
@@ -252,7 +255,10 @@ function set(obj, path, value) {
 function zipObject(keys, values) {
   const out = {};
 
-  for (let i = 0, l = keys.length; i < l; ++i) {
+  for (let i = 0, l = keys.length; i < l; ++i) {    
+    if (keys[i] === '__proto__') {
+      return false;
+    }
     out[keys[i]] = values[i];
   }
 


### PR DESCRIPTION
Fix prototype pollution when path components are not strings