### PR TITLE
Make all named exports work for ESM

### DIFF
--- a/lib/objection.js
+++ b/lib/objection.js
@@ -1,6 +1,14 @@
 'use strict';
 
-const { wrapError, ...DbErrorClasses } = require('db-errors');
+const {
+  DBError,
+  UniqueViolationError,
+  NotNullViolationError,
+  ForeignKeyViolationError,
+  ConstraintViolationError,
+  CheckViolationError,
+  DataError,
+} = require('db-errors');
 const { Model: NativeModel } = require('./model/Model');
 const { QueryBuilder: NativeQueryBuilder } = require('./queryBuilder/QueryBuilder');
 const { QueryBuilderBase } = require('./queryBuilder/QueryBuilderBase');
@@ -88,5 +96,11 @@ module.exports = {
   knexSnakeCaseMappers,
   knexIdentifierMapping,
 
-  ...DbErrorClasses,
+  DBError,
+  UniqueViolationError,
+  NotNullViolationError,
+  ForeignKeyViolationError,
+  ConstraintViolationError,
+  CheckViolationError,
+  DataError,
 };


### PR DESCRIPTION
Even though #2023 was already closed, I noticed that the db-errors classes can't be import named in ESM projects:
https://github.com/Vincit/objection.js/issues/2023#issuecomment-1064511975

The problem is the used spread operator. The classes need to be exported explicitly for this to work. this PR fixes the remaining broken exports.
