### PR TITLE
Update WhereIN TS-defs to use readonly primitive arrays

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -405,7 +405,7 @@ declare namespace Objection {
     <QBP extends QB>(col: ModelProps<ModelType<QBP>>, cb: CallbackVoid<QB>): QB;
     <QBP extends QB>(col: ModelProps<ModelType<QBP>>, qb: AnyQueryBuilder): QB;
 
-    (col: ColumnRef | ColumnRef[], expr: Expression<PrimitiveValue>[]): QB;
+    (col: ColumnRef | ColumnRef[], expr: readonly Expression<PrimitiveValue>[]): QB;
     (col: ColumnRef | ColumnRef[], cb: CallbackVoid<QB>): QB;
     (col: ColumnRef | ColumnRef[], qb: AnyQueryBuilder): QB;
   }
@@ -451,17 +451,17 @@ declare namespace Objection {
   }
 
   interface WhereCompositeMethod<QB extends AnyQueryBuilder> {
-    (column: ColumnRef[], op: Operator, expr: Expression<PrimitiveValue>[]): QB;
-    (column: ColumnRef, expr: Expression<PrimitiveValue>): QB;
+    (column: ColumnRef[], op: Operator, expr: readonly Expression<PrimitiveValue>[]): QB;
+    (column: ColumnRef, expr: readonly Expression<PrimitiveValue>): QB;
     (column: ColumnRef, op: Operator, expr: Expression<PrimitiveValue>): QB;
-    (column: ColumnRef[], expr: Expression<PrimitiveValue>[]): QB;
+    (column: ColumnRef[], expr: readonly Expression<PrimitiveValue>[]): QB;
     (column: ColumnRef[], qb: AnyQueryBuilder): QB;
   }
 
   interface WhereInCompositeMethod<QB extends AnyQueryBuilder> {
-    (column: ColumnRef, expr: Expression<PrimitiveValue>[]): QB;
+    (column: ColumnRef, expr: readonly Expression<PrimitiveValue>[]): QB;
     (column: ColumnRef, qb: AnyQueryBuilder): QB;
-    (column: ColumnRef[], expr: Expression<PrimitiveValue>[][]): QB;
+    (column: ColumnRef[], expr: readonly Expression<PrimitiveValue>[][]): QB;
     (column: ColumnRef[], qb: AnyQueryBuilder): QB;
   }
 


### PR DESCRIPTION
Because doing something like:
```
await knex('workflow').whereIn(myArray)
```
will not modify `myArray`, if we mark the TS-type as ReadOnly, it makes the type more accessible for a variety of use-cases (i.e. readonly arrays can be passed in). Note that mutable arrays can still be cast into read only so this is "backwards compatible" type-wise.

**Fixes #2271**