### PR TITLE
fix: improved typing for ModelObject<T>

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -192,9 +192,7 @@ declare namespace Objection {
   /**
    * A Pojo version of model.
    */
-  type ModelObject<T extends Model> = {
-    [K in DataPropertyNames<T>]: T[K];
-  };
+  type ModelObject<T extends Model> = Pick<T, DataPropertyNames<T>>;
 
   /**
    * Any object that has some of the properties of model class T match this type.


### PR DESCRIPTION
The current ModelObject<T> does not preserve `?` optional properties.  

Example:
```typescript
export class User extends Model {
  id: string;
  name: string;
  parentId?: User
}

function insertUser(user: Omit<ModelObject<User>, "id">) {...}

// Typescript will throw an error here. Missing property parentId
insertUser({
    name: "john"
});

// Unfortunately, I have to manually set parentId: undefined
insertUser({
    name: "john",
    parentId: undefined
});
```

It's not surprising since with this declaration we lose the `?` optional syntax
```typescript
type ModelObject<T extends Model> = {
    [K in DataPropertyNames<T>]: T[K];
};
```
Typescript has a native `Pick<Type, Keys>` utility Type for this which preserves optional properties and allows a shorter syntax.

Not sure if it can be used also for `PartialModelObject`
What do you think ?