### PR TITLE
Simplify ReturningMethod type so that it avoids infinite type recursion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "objection",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "objection",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.6.2",

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -628,11 +628,9 @@ declare namespace Objection {
     <QB extends AnyQueryBuilder>(
       this: QB,
       column: string | string[]
-    ): QB extends ArrayQueryBuilder<QB>
+    ): QB extends NumberQueryBuilder<QB>
       ? ArrayQueryBuilder<QB>
-      : QB extends NumberQueryBuilder<QB>
-      ? ArrayQueryBuilder<QB>
-      : SingleQueryBuilder<QB>;
+      : QB;
   }
 
   interface TimeoutOptions {


### PR DESCRIPTION
Fixes #2277 

I am not an expert on TypeScript typings, but this problem seemed very much like the one described at [a related blog article](https://www.angularfix.com/2022/01/why-am-i-getting-instantiation-is.html) , so I tried my stab at it.

It seems to solve the problem, but I cannot guarantee if it causes some other problems. Then again, 'any' typed query builders disregard the problems anyway...