### PR TITLE
Improve ModelObject type

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -197,6 +197,26 @@ declare namespace Objection {
   };
 
   /**
+   * Returns keys that have function as their type.
+   */
+  type KeysWithFunctionType<T> = {
+    [K in keyof T]: T[K] extends Function ? K : never;
+  }[keyof T];
+
+  /**
+   * Like ModelObject, but preserves information about optionality.
+   *
+   * Removes keys that:
+   * - start with '$'
+   * - are 'QueryBuilderType'
+   * - have function type
+   */
+  export type ModelProperties<T extends Model> = Pick<
+    T,
+    Exclude<keyof T, `$${string}` | 'QueryBuilderType' | KeysWithFunctionType<T>>
+  >;
+
+  /**
    * Any object that has some of the properties of model class T match this type.
    */
   type PartialModelObject<T extends Model> = {


### PR DESCRIPTION
Let's say there's a user model called `User`:

```ts
class UserModel extends Model {
  id!: number;
  email?: string;
}
```

Now we want to add a new user with `User.query().insert` method. 

Let's define the parameter of `insert` method as `userToInsert`. 

```ts
const userToInsert = { ... };
User.query().insert(userToInsert);
```

Objection provides (at least) two types that could be used for `userToInsert`: `PartialModelObject` and `ModelObject`.

The problem with these types is that `PartialModelObject` makes all properties optional where `ModelObject` makes them required.

Wanted end result:
```ts
// ERROR!
const userToInsert = {}

// OK
const userToInsert = {
  id: 1
}

// ERROR!
const userToInsert = {
  email: 'example@email.com'
}
```

-----

I have created a new type `ModelProperties<T>` that fixes the issue and works as above.

It could be a good idea to refactor `objection` to use it instead of `PartialModelObject` and `ModelObject`. This way objections methods would also have stronger typings.