### PR TITLE
Updates types for TS 4.8

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1008,7 +1008,7 @@ declare namespace Objection {
     timeout: TimeoutMethod<this>;
     columnInfo: ColumnInfoMethod<this>;
 
-    toKnexQuery<T = ModelObject<M>>(): Knex.QueryBuilder<T, T[]>;
+    toKnexQuery<T extends {} = ModelObject<M>>(): Knex.QueryBuilder<T, T[]>;
     clone(): this;
 
     page(page: number, pageSize: number): PageQueryBuilder<this>;


### PR DESCRIPTION
Typescript 4.8 assumes that unconstrained types extend `unknown`, not `{}` (which is `unknown` minus `null` and `undefined`). However, many uses still need to extend `{}`. This PR does that explicitly for objection's types.

See https://devblogs.microsoft.com/typescript/announcing-typescript-4-8-beta/#unconstrained-generics-no-longer-assignable-to