### PR TITLE
Fix typos on usage examples

### DIFF
--- a/examples/koa-ts/client.js
+++ b/examples/koa-ts/client.js
@@ -14,7 +14,7 @@ const req = axios.create({
 })
 
 ;(async () => {
-  const matt = await inserPersonWithRelations()
+  const matt = await insertPersonWithRelations()
   await fetchPeople()
 
   await updatePerson(matt, { age: 41 })
@@ -47,7 +47,7 @@ const req = axios.create({
   }
 })
 
-async function inserPersonWithRelations() {
+async function insertPersonWithRelations() {
   console.log(`
     ////////////////////////////////////////////////
     //       Insert a person with relations       //

--- a/examples/koa/client.js
+++ b/examples/koa/client.js
@@ -14,7 +14,7 @@ const req = axios.create({
 })
 
 ;(async () => {
-  const matt = await inserPersonWithRelations()
+  const matt = await insertPersonWithRelations()
   await fetchPeople()
 
   await updatePerson(matt, { age: 41 })
@@ -43,7 +43,7 @@ const req = axios.create({
   console.error('error:', err.response.status, err.response.data)
 })
 
-async function inserPersonWithRelations() {
+async function insertPersonWithRelations() {
   console.log(`
     ////////////////////////////////////////////////
     //       Insert a person with relations       //


### PR DESCRIPTION
Just rename `inser` to `insert` in the methods names.

Closes #2311 