### PR TITLE
Make relation join error due to lack of initialization a bit more explicit

### DIFF
--- a/lib/queryBuilder/join/RelationJoiner.js
+++ b/lib/queryBuilder/join/RelationJoiner.js
@@ -285,7 +285,7 @@ function getAllColumnSelectionsForNode({ builder, tableNode }) {
 
   if (!tableMeta) {
     throw new Error(
-      'table metadata has not been fetched. Are you trying to call toKnexQuery() for a withGraphJoined query? To make sure the table metadata is fetched see the objection.initialize function.'
+      `table metadata has not been fetched for table '${table}'. Are you trying to call toKnexQuery() for a withGraphJoined query? To make sure the table metadata is fetched see the objection.initialize function.`
     );
   }
 


### PR DESCRIPTION
Make relation joiner error a bit more explicit.