### PR TITLE
fix issue 2192

### DIFF
--- a/lib/utils/identifierMapping.js
+++ b/lib/utils/identifierMapping.js
@@ -135,6 +135,7 @@ function isDigit(char) {
 // If no separators are found, `mapper` is called for the entire string.
 function mapLastPart(mapper, separator) {
   return (str) => {
+    if (!str) return str;
     const idx = str.lastIndexOf(separator);
     const mapped = mapper(str.slice(idx + separator.length));
     return str.slice(0, idx + separator.length) + mapped;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "objection",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "objection",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.6.2",

--- a/tests/integration/knexSnakeCase.js
+++ b/tests/integration/knexSnakeCase.js
@@ -4,7 +4,7 @@ const { Model, knexSnakeCaseMappers } = require('../../');
 const { expect } = require('chai');
 
 module.exports = (session) => {
-  describe.only('knexSnakeCaseMappers', () => {
+  describe('knexSnakeCaseMappers', () => {
     let knex;
 
     class Person extends Model {
@@ -185,9 +185,9 @@ module.exports = (session) => {
         return knex.schema
           .dropTableIfExists('emptyConstraintName')
           .createTable('emptyConstraintName', (table) => {
-            table.integer('id').primary()
-          })
-      })
+            table.integer('id').primary();
+          });
+      });
     });
 
     describe('queries', () => {

--- a/tests/integration/knexSnakeCase.js
+++ b/tests/integration/knexSnakeCase.js
@@ -4,7 +4,7 @@ const { Model, knexSnakeCaseMappers } = require('../../');
 const { expect } = require('chai');
 
 module.exports = (session) => {
-  describe('knexSnakeCaseMappers', () => {
+  describe.only('knexSnakeCaseMappers', () => {
     let knex;
 
     class Person extends Model {
@@ -178,6 +178,16 @@ module.exports = (session) => {
           expect(hasTable).to.equal(false);
         });
       });
+
+      // test for the error: 2192
+      // TypeError: Cannot read properties of undefined (reading 'lastIndexOf')
+      it('createTable with empty constraintName', () => {
+        return knex.schema
+          .dropTableIfExists('emptyConstraintName')
+          .createTable('emptyConstraintName', (table) => {
+            table.integer('id').primary()
+          })
+      })
     });
 
     describe('queries', () => {


### PR DESCRIPTION
Hey Everyone, this PR fix the issue: https://github.com/Vincit/objection.js/issues/2192 based on the solution that was proposed there.

The only difference is to avoid to check the `typeof` for performance reasons. Empty strings | null | undefined will return the same.