### PR TITLE
add support for aliasing with `.as()` in ValueBuilder

### DIFF
--- a/lib/queryBuilder/ValueBuilder.js
+++ b/lib/queryBuilder/ValueBuilder.js
@@ -63,6 +63,10 @@ class ValueBuilder {
   }
 
   toKnexRaw(builder) {
+    return builder.knex().raw(...this._createRawArgs(builder));
+  }
+
+  _createRawArgs(builder) {
     let sql = null;
     let bindings = null;
 
@@ -81,7 +85,7 @@ class ValueBuilder {
       sql = `CAST(${sql} AS ${this._cast})`;
     }
 
-    return builder.knex().raw(sql, bindings);
+    return [sql, bindings];
   }
 }
 

--- a/lib/queryBuilder/ValueBuilder.js
+++ b/lib/queryBuilder/ValueBuilder.js
@@ -80,9 +80,9 @@ class ValueBuilder {
       bindings.push(JSON.stringify(this._value));
       sql = '?';
     } else if (this._toArray) {
-      const valueAsArray = asArray(this._value);
-      bindings.push(...valueAsArray.map((it) => buildArg(it, builder)));
-      sql = `ARRAY[${valueAsArray.map(() => '?').join(', ')}]`;
+      const values = asArray(this._value);
+      bindings.push(...values.map((it) => buildArg(it, builder)));
+      sql = `ARRAY[${values.map(() => '?').join(', ')}]`;
     } else {
       bindings.push(this._value);
       sql = '?';

--- a/lib/queryBuilder/ValueBuilder.js
+++ b/lib/queryBuilder/ValueBuilder.js
@@ -10,6 +10,7 @@ class ValueBuilder {
     // Cast objects and arrays to json by default.
     this._toJson = isObject(value);
     this._toArray = false;
+    this._alias = null;
   }
 
   get cast() {
@@ -62,27 +63,38 @@ class ValueBuilder {
     return this;
   }
 
+  as(alias) {
+    this._alias = alias;
+    return this;
+  }
+
   toKnexRaw(builder) {
     return builder.knex().raw(...this._createRawArgs(builder));
   }
 
   _createRawArgs(builder) {
     let sql = null;
-    let bindings = null;
+    let bindings = [];
 
     if (this._toJson) {
-      bindings = JSON.stringify(this._value);
+      bindings.push(JSON.stringify(this._value));
       sql = '?';
     } else if (this._toArray) {
-      bindings = asArray(this._value).map((it) => buildArg(it, builder));
-      sql = `ARRAY[${bindings.map(() => '?').join(', ')}]`;
+      const valueAsArray = asArray(this._value);
+      bindings.push(...valueAsArray.map((it) => buildArg(it, builder)));
+      sql = `ARRAY[${valueAsArray.map(() => '?').join(', ')}]`;
     } else {
-      bindings = this._value;
+      bindings.push(this._value);
       sql = '?';
     }
 
     if (this._cast) {
       sql = `CAST(${sql} AS ${this._cast})`;
+    }
+
+    if (this._alias) {
+      bindings.push(this._alias);
+      sql = `${sql} as ??`;
     }
 
     return [sql, bindings];

--- a/tests/unit/queryBuilder/ValueBuilder.js
+++ b/tests/unit/queryBuilder/ValueBuilder.js
@@ -1,0 +1,30 @@
+const expect = require('expect.js');
+const { val, Model } = require('../../../');
+const { ValueBuilder } = require('../../../lib/queryBuilder/ValueBuilder');
+
+function toRawArgs(ref) {
+  return ref._createRawArgs(Model.query());
+}
+
+describe('ValueBuilder', () => {
+  it('should create ValueBuilder', () => {
+    let builder = val('Awwww.ItWorks');
+    expect(builder instanceof ValueBuilder).to.be.ok();
+    expect(toRawArgs(builder)).to.eql(['?', 'Awwww.ItWorks']);
+  });
+
+  it('should allow casting', () => {
+    let builder = val('100').castBigInt();
+    expect(toRawArgs(builder)).to.eql(['CAST(? AS bigint)', '100']);
+  });
+
+  it('should stringify when casting to json', () => {
+    let builder = val({ value: 100 }).castJson();
+    expect(toRawArgs(builder)).to.eql(['CAST(? AS jsonb)', '{"value":100}']);
+  });
+
+  it('should expand arrays', () => {
+    let builder = val([1, 2, 3]).asArray();
+    expect(toRawArgs(builder)).to.eql(['ARRAY[?, ?, ?]', [1, 2, 3]]);
+  });
+});

--- a/tests/unit/queryBuilder/ValueBuilder.js
+++ b/tests/unit/queryBuilder/ValueBuilder.js
@@ -10,21 +10,31 @@ describe('ValueBuilder', () => {
   it('should create ValueBuilder', () => {
     let builder = val('Awwww.ItWorks');
     expect(builder instanceof ValueBuilder).to.be.ok();
-    expect(toRawArgs(builder)).to.eql(['?', 'Awwww.ItWorks']);
+    expect(toRawArgs(builder)).to.eql(['?', ['Awwww.ItWorks']]);
   });
 
   it('should allow casting', () => {
     let builder = val('100').castBigInt();
-    expect(toRawArgs(builder)).to.eql(['CAST(? AS bigint)', '100']);
+    expect(toRawArgs(builder)).to.eql(['CAST(? AS bigint)', ['100']]);
   });
 
   it('should stringify when casting to json', () => {
     let builder = val({ value: 100 }).castJson();
-    expect(toRawArgs(builder)).to.eql(['CAST(? AS jsonb)', '{"value":100}']);
+    expect(toRawArgs(builder)).to.eql(['CAST(? AS jsonb)', ['{"value":100}']]);
   });
 
   it('should expand arrays', () => {
     let builder = val([1, 2, 3]).asArray();
     expect(toRawArgs(builder)).to.eql(['ARRAY[?, ?, ?]', [1, 2, 3]]);
+  });
+
+  it('should support aliasing', () => {
+    let builder = val('Hello').as('greeting');
+    expect(toRawArgs(builder)).to.eql(['? as ??', ['Hello', 'greeting']]);
+  });
+
+  it('should support simultaneous casting and aliasing', () => {
+    let builder = val('1').castBigInt().as('total');
+    expect(toRawArgs(builder)).to.eql(['CAST(? AS bigint) as ??', ['1', 'total']]);
   });
 });


### PR DESCRIPTION
the Typescript typings claim that this method already exists.