### PR TITLE
chore: Add Buffer[] to PrimitiveValue

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -132,7 +132,8 @@ declare namespace Objection {
     | boolean[]
     | Date[]
     | null
-    | Buffer;
+    | Buffer
+    | Buffer[];
 
   type Expression<T> = T | Raw | ReferenceBuilder | ValueBuilder | AnyQueryBuilder;
 


### PR DESCRIPTION
chore: Add Buffer[] to PrimitiveValue
---
Add `Buffer[]` to `PrimitiveValue` which would allow to use array of binary data in queries such as 
```ts
this.repository.query().andWhere('id', 'IN', binaryUserIds)
```