### PR TITLE
adjustments for knex v1 and v2

### DIFF
--- a/lib/queryBuilder/JoinBuilder.js
+++ b/lib/queryBuilder/JoinBuilder.js
@@ -120,6 +120,10 @@ class JoinBuilder extends QueryBuilderOperationSupport {
     return this.addOperation(new KnexOperation('andOnNotBetween'), args);
   }
 
+  andOnJsonPathEquals(...args) {
+    return this.addOperation(new KnexOperation('andOnJsonPathEquals'), args);
+  }
+
   onVal(...args) {
     return this.addOperation(new KnexOperation('onVal'), args);
   }

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -1274,11 +1274,16 @@ async function chainHooks(promise, builder, func) {
 }
 
 function createModels(result, builder) {
-  const modelClass = builder.resultModelClass();
-
   if (result === null || result === undefined) {
     return null;
   }
+
+  if (builder.isInsert()) {
+    // results are applied to input models in `InsertOperation.onAfter1` instead.
+    return result;
+  }
+
+  const modelClass = builder.resultModelClass();
 
   if (Array.isArray(result)) {
     if (result.length && shouldBeConvertedToModel(result[0], modelClass)) {

--- a/lib/queryBuilder/QueryBuilderBase.js
+++ b/lib/queryBuilder/QueryBuilderBase.js
@@ -105,6 +105,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     return this.addOperation(new KnexOperation('fromJS'), args);
   }
 
+  fromRaw(...args) {
+    return this.addOperation(new KnexOperation('fromRaw'), args);
+  }
+
   into(...args) {
     return this.addOperation(new KnexOperation('into'), args);
   }
@@ -279,6 +283,30 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
 
   orWhereNotBetween(...args) {
     return this.addOperation(new KnexOperation('orWhereNotBetween'), args);
+  }
+
+  whereLike(...args) {
+    return this.addOperation(new KnexOperation('whereLike'), args);
+  }
+
+  andWhereLike(...args) {
+    return this.addOperation(new KnexOperation('andWhereLike'), args);
+  }
+
+  orWhereLike(...args) {
+    return this.addOperation(new KnexOperation('orWhereLike'), args);
+  }
+
+  whereILike(...args) {
+    return this.addOperation(new KnexOperation('whereILike'), args);
+  }
+
+  andWhereILike(...args) {
+    return this.addOperation(new KnexOperation('andWhereILike'), args);
+  }
+
+  orWhereILike(...args) {
+    return this.addOperation(new KnexOperation('orWhereILike'), args);
   }
 
   groupBy(...args) {
@@ -481,6 +509,14 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     return this.addOperation(new KnexOperation('withRecursive'), args);
   }
 
+  withMaterialized(...args) {
+    return this.addOperation(new KnexOperation('withMaterialized'), args);
+  }
+
+  withNotMaterialized(...args) {
+    return this.addOperation(new KnexOperation('withNotMaterialized'), args);
+  }
+
   whereComposite(...args) {
     return this.addOperation(new WhereCompositeOperation('whereComposite'), args);
   }
@@ -513,11 +549,70 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     return this.addOperation(operation, args);
   }
 
+  jsonExtract(...args) {
+    return this.addOperation(new KnexOperation('jsonExtract'), args);
+  }
+
+  jsonSet(...args) {
+    return this.addOperation(new KnexOperation('jsonSet'), args);
+  }
+
+  jsonInsert(...args) {
+    return this.addOperation(new KnexOperation('jsonInsert'), args);
+  }
+
+  jsonRemove(...args) {
+    return this.addOperation(new KnexOperation('jsonRemove'), args);
+  }
+
+  whereJsonObject(...args) {
+    return this.addOperation(new KnexOperation('whereJsonObject'), args);
+  }
+
+  orWhereJsonObject(...args) {
+    return this.addOperation(new KnexOperation('orWhereJsonObject'), args);
+  }
+
+  andWhereJsonObject(...args) {
+    return this.addOperation(new KnexOperation('andWhereJsonObject'), args);
+  }
+
+  whereNotJsonObject(...args) {
+    return this.addOperation(new KnexOperation('whereNotJsonObject'), args);
+  }
+
+  orWhereNotJsonObject(...args) {
+    return this.addOperation(new KnexOperation('orWhereNotJsonObject'), args);
+  }
+
+  andWhereNotJsonObject(...args) {
+    return this.addOperation(new KnexOperation('andWhereNotJsonObject'), args);
+  }
+
+  whereJsonPath(...args) {
+    return this.addOperation(new KnexOperation('whereJsonPath'), args);
+  }
+
+  orWhereJsonPath(...args) {
+    return this.addOperation(new KnexOperation('orWhereJsonPath'), args);
+  }
+
+  andWhereJsonPath(...args) {
+    return this.addOperation(new KnexOperation('andWhereJsonPath'), args);
+  }
+
+  // whereJson(Not)SupersetOf / whereJson(Not)SubsetOf are now supported by knex >= 1.0, but for now
+  // objection handles them differently and only for postgres.
+  // Changing them to utilize knex methods directly may require a major version bump and upgrade guide.
   whereJsonSupersetOf(...args) {
     return this.addOperation(
       new WhereJsonPostgresOperation('whereJsonSupersetOf', { operator: '@>', bool: 'and' }),
       args
     );
+  }
+
+  andWhereJsonSupersetOf(...args) {
+    return this.whereJsonSupersetOf(...args);
   }
 
   orWhereJsonSupersetOf(...args) {
@@ -538,6 +633,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     );
   }
 
+  andWhereJsonNotSupersetOf(...args) {
+    return this.andWhereJsonNotSupersetOf(...args);
+  }
+
   orWhereJsonNotSupersetOf(...args) {
     return this.addOperation(
       new WhereJsonPostgresOperation('orWhereJsonNotSupersetOf', {
@@ -556,6 +655,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
     );
   }
 
+  andWhereJsonSubsetOf(...args) {
+    return this.whereJsonSubsetOf(...args);
+  }
+
   orWhereJsonSubsetOf(...args) {
     return this.addOperation(
       new WhereJsonPostgresOperation('orWhereJsonSubsetOf', { operator: '<@', bool: 'or' }),
@@ -572,6 +675,10 @@ class QueryBuilderBase extends QueryBuilderOperationSupport {
       }),
       args
     );
+  }
+
+  andWhereJsonNotSubsetOf(...args) {
+    return this.whereJsonNotSubsetOf(...args);
   }
 
   orWhereJsonNotSubsetOf(...args) {

--- a/lib/queryBuilder/operations/InsertOperation.js
+++ b/lib/queryBuilder/operations/InsertOperation.js
@@ -55,7 +55,7 @@ class InsertOperation extends QueryBuilderOperation {
       // If the user specified a `returning` clause the result may be an array of objects.
       // Merge all values of the objects to our models.
       for (let i = 0, l = this.models.length; i < l; ++i) {
-        this.models[i].$set(ret[i]);
+        this.models[i].$setDatabaseJson(ret[i]);
       }
     } else {
       // If the return value is not an array of objects, we assume it is an array of identifiers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,13 @@
         "eslint-formatter-codeframe": "^7.32.1",
         "eslint-plugin-prettier": "^4.0.0",
         "expect.js": "^0.3.1",
-        "knex": "0.95.13",
+        "knex": ">=0.95.13",
         "mocha": "^9.1.3",
         "mysql": "^2.18.1",
         "pg": "^8.7.1",
         "prettier": "2.4.1",
         "sqlite3": "^5.0.2",
-        "typescript": "^4.5.4",
+        "typescript": ">=4.5.4",
         "vuepress": "1.8.2"
       },
       "engines": {
@@ -1979,9 +1979,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+      "version": "16.18.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
+      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
       "dev": true
     },
     "node_modules/@types/q": {
@@ -5051,9 +5051,9 @@
       "dev": true
     },
     "node_modules/colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -5069,12 +5069,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
       "engines": {
-        "node": ">= 10"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commondir": {
@@ -6144,9 +6144,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -8187,6 +8187,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -8225,9 +8234,9 @@
       }
     },
     "node_modules/getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
       "dev": true
     },
     "node_modules/getpass": {
@@ -10025,32 +10034,36 @@
       }
     },
     "node_modules/knex": {
-      "version": "0.95.13",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.13.tgz",
-      "integrity": "sha512-XagG/iYA4RabYy1BmgY607Q00kBduOgb/Nej3+UDcCNdmuzDvZcfFo/726BYhfxv5amTBtGjewodZrTNbO63VA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
+      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
       "dev": true,
       "dependencies": {
-        "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "bin": {
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
         "mysql": {
           "optional": true
         },
@@ -13574,15 +13587,15 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/reduce": {
@@ -14797,24 +14810,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -15613,9 +15608,9 @@
       }
     },
     "node_modules/tarn": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
-      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+      "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -16131,16 +16126,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/uc.micro": {
@@ -19848,9 +19843,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+      "version": "16.18.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
+      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
       "dev": true
     },
     "@types/q": {
@@ -22397,9 +22392,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "combined-stream": {
@@ -22412,9 +22407,9 @@
       }
     },
     "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true
     },
     "commondir": {
@@ -23290,9 +23285,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -24914,6 +24909,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -24940,9 +24941,9 @@
       "dev": true
     },
     "getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
       "dev": true
     },
     "getpass": {
@@ -26324,23 +26325,24 @@
       "dev": true
     },
     "knex": {
-      "version": "0.95.13",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.13.tgz",
-      "integrity": "sha512-XagG/iYA4RabYy1BmgY607Q00kBduOgb/Nej3+UDcCNdmuzDvZcfFo/726BYhfxv5amTBtGjewodZrTNbO63VA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
+      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
       "dev": true,
       "requires": {
-        "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "dependencies": {
@@ -29215,12 +29217,12 @@
       }
     },
     "rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "requires": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       }
     },
     "reduce": {
@@ -30222,18 +30224,6 @@
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
         "socks": "^2.6.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "sort-keys": {
@@ -30885,9 +30875,9 @@
       }
     },
     "tarn": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
-      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+      "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
       "dev": true
     },
     "term-size": {
@@ -31293,9 +31283,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true
     },
     "uc.micro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-formatter-codeframe": "^7.32.1",
         "eslint-plugin-prettier": "^4.0.0",
         "expect.js": "^0.3.1",
-        "knex": ">=0.95.13",
+        "knex": ">=1.0.1",
         "mocha": "^9.1.3",
         "mysql": "^2.18.1",
         "pg": "^8.7.1",
@@ -33,7 +33,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "knex": ">=0.95.0"
+        "knex": ">=1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "db-errors": "^0.2.3"
   },
   "peerDependencies": {
-    "knex": ">=0.95.0"
+    "knex": ">=1.0.1"
   },
   "devDependencies": {
     "@types/node": "^16.11.6",
@@ -67,7 +67,7 @@
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-prettier": "^4.0.0",
     "expect.js": "^0.3.1",
-    "knex": ">=0.95.13",
+    "knex": ">=1.0.1",
     "mocha": "^9.1.3",
     "mysql": "^2.18.1",
     "pg": "^8.7.1",

--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-prettier": "^4.0.0",
     "expect.js": "^0.3.1",
-    "knex": "0.95.13",
+    "knex": ">=0.95.13",
     "mocha": "^9.1.3",
     "mysql": "^2.18.1",
     "pg": "^8.7.1",
     "prettier": "2.4.1",
     "sqlite3": "^5.0.2",
-    "typescript": "^4.5.4",
+    "typescript": ">=4.5.4",
     "vuepress": "1.8.2"
   }
 }

--- a/tests/integration/graph/GraphInsert.js
+++ b/tests/integration/graph/GraphInsert.js
@@ -1154,7 +1154,7 @@ module.exports = (session) => {
           for (const prop of Object.keys(jsonSchemaProps)) {
             const propSchema = jsonSchemaProps[prop];
 
-            if (propSchema.type === 'boolean') {
+            if (propSchema.type === 'boolean' && prop in json) {
               json[prop] = !!json[prop];
             }
           }

--- a/tests/integration/misc/#1202.js
+++ b/tests/integration/misc/#1202.js
@@ -78,14 +78,14 @@ module.exports = (session) => {
         .knex('persons')
         .insert({ name: 'Meinhart ' })
         .returning('id')
-        .then(([id]) => {
+        .then(([{ id }]) => {
           return session.knex('persons').insert({ name: 'Arnold', parentId: id }).returning('id');
         })
-        .then(([arnoldId]) => {
+        .then(([{ id: arnoldId }]) => {
           return Promise.all([
             session.knex('persons').insert({ name: 'Hans' }).returning('id'),
             session.knex('persons').insert({ name: 'Urs' }).returning('id'),
-          ]).then(([[hansId], [ursId]]) => {
+          ]).then(([[{ id: hansId }], [{ id: ursId }]]) => {
             return Promise.all([
               session.knex('cousins').insert({ id1: arnoldId, id2: hansId }),
               session.knex('cousins').insert({ id1: arnoldId, id2: ursId }),

--- a/tests/unit/queryBuilder/JoinBuilder.js
+++ b/tests/unit/queryBuilder/JoinBuilder.js
@@ -1,0 +1,29 @@
+const expect = require('expect.js');
+const objection = require('../../../');
+const Model = objection.Model;
+const { JoinBuilder } = require('../../../lib/queryBuilder/JoinBuilder');
+const JoinClause = require('knex/lib/query/joinclause');
+
+describe('JoinBuilder', () => {
+  it('should have knex.JoinClause methods', () => {
+    class TestModel extends Model {
+      static get tableName() {
+        return 'Model';
+      }
+    }
+
+    let ignore = [];
+
+    let knexJoinClause = new JoinClause();
+    let builder = JoinBuilder.forClass(TestModel);
+    for (let name in knexJoinClause) {
+      let func = knexJoinClause[name];
+      console.log('checking', name, typeof func);
+      if (typeof func === 'function' && ignore.indexOf(name) === -1) {
+        if (typeof builder[name] !== 'function') {
+          expect().to.fail("knex method '" + name + "' is missing from JoinBuilder");
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -61,17 +61,6 @@ describe('QueryBuilder', () => {
 
   it('should have knex methods', () => {
     let ignore = [
-      'and',
-      'toSQL',
-      'bind',
-      'timeout',
-      'connection',
-      'stream',
-      'finally',
-      'yield',
-      'ensure',
-      'reflect',
-      'domain',
       'setMaxListeners',
       'getMaxListeners',
       'emit',
@@ -86,10 +75,13 @@ describe('QueryBuilder', () => {
       'listenerCount',
       'eventNames',
       'rawListeners',
+      'pluck', // not supported anymore in objection v3+
+      'queryBuilder', // this method is added to the knex mock, but should not available on objection's QueryBuilder
+      'raw', // this method is added to the knex mock, but should not available on objection's QueryBuilder
     ];
 
     let builder = QueryBuilder.forClass(TestModel);
-    for (let name in mockKnex.queryBuilder()) {
+    for (let name in mockKnex) {
       let func = mockKnex[name];
       if (typeof func === 'function' && name.charAt(0) !== '_' && ignore.indexOf(name) === -1) {
         if (typeof builder[name] !== 'function') {

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -362,6 +362,59 @@ declare namespace Objection {
     (table: TableRef<QB>): QB;
   }
 
+  interface FromRawMethod<QB extends AnyQueryBuilder> extends RawInterface<QB> {}
+
+  interface JsonExtraction {
+    column: string | Raw | Knex.QueryBuilder;
+    path: string;
+    alias?: string;
+    singleValue?: boolean;
+  }
+
+  interface JsonExtract<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(
+      column: ModelProps<ModelType<QBP>>,
+      path: string,
+      alias?: string,
+      singleValue?: boolean
+    ): QB;
+
+    (column: ColumnRef, path: string, alias?: string, singleValue?: boolean): QB;
+    (column: JsonExtraction[] | any[][], singleValue?: boolean): QB;
+  }
+
+  interface JsonSet<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(
+      column: ModelProps<ModelType<QBP>>,
+      path: string,
+      value: any,
+      alias?: string
+    ): QB;
+
+    (column: ColumnRef, path: string, value: any, alias?: string): QB;
+  }
+
+  interface JsonInsert<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(
+      column: ModelProps<ModelType<QBP>>,
+      path: string,
+      value: any,
+      alias?: string
+    ): QB;
+
+    (column: ColumnRef, path: string, value: any, alias?: string): QB;
+  }
+
+  interface JsonRemove<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(column: ModelProps<ModelType<QBP>>, path: string, alias?: string): QB;
+
+    (column: ColumnRef, path: string, alias?: string): QB;
+  }
+
   interface WhereMethod<QB extends AnyQueryBuilder> {
     // These must come first so that we get autocomplete.
     <QBP extends QB>(
@@ -425,6 +478,25 @@ declare namespace Objection {
 
     (col1: ColumnRef, op: Operator, col2: ColumnRef): QB;
     (col1: ColumnRef, col2: ColumnRef): QB;
+  }
+
+  interface WhereJsonObject<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(col: ModelProps<ModelType<QBP>>, value: any): QB;
+
+    (col: ColumnRef, value: any): QB;
+  }
+
+  interface WhereJsonPath<QB extends AnyQueryBuilder> {
+    // These must come first so that we get autocomplete.
+    <QBP extends QB>(
+      col: ModelProps<ModelType<QBP>>,
+      jsonPath: string,
+      operator: string,
+      value: any
+    ): QB;
+
+    (col: ColumnRef, jsonPath: string, operator: string, value: any): QB;
   }
 
   interface WhereJsonMethod<QB extends AnyQueryBuilder> {
@@ -790,6 +862,12 @@ declare namespace Objection {
     from: FromMethod<this>;
     table: FromMethod<this>;
     into: FromMethod<this>;
+    fromRaw: FromRawMethod<this>;
+
+    jsonExtract: JsonExtract<this>;
+    jsonSet: JsonSet<this>;
+    jsonInsert: JsonInsert<this>;
+    jsonRemove: JsonRemove<this>;
 
     where: WhereMethod<this>;
     andWhere: WhereMethod<this>;
@@ -797,6 +875,12 @@ declare namespace Objection {
     whereNot: WhereMethod<this>;
     andWhereNot: WhereMethod<this>;
     orWhereNot: WhereMethod<this>;
+    whereLike: WhereMethod<this>;
+    andWhereLike: WhereMethod<this>;
+    orWhereLike: WhereMethod<this>;
+    whereILike: WhereMethod<this>;
+    andWhereILike: WhereMethod<this>;
+    orWhereILike: WhereMethod<this>;
 
     whereRaw: WhereRawMethod<this>;
     orWhereRaw: WhereRawMethod<this>;
@@ -834,13 +918,28 @@ declare namespace Objection {
     orWhereNotColumn: WhereColumnMethod<this>;
     andWhereNotColumn: WhereColumnMethod<this>;
 
+    whereJsonObject: WhereJsonObject<this>;
+    orWhereJsonObject: WhereJsonObject<this>;
+    andWhereJsonObject: WhereJsonObject<this>;
+    whereNotJsonObject: WhereJsonObject<this>;
+    orWhereNotJsonObject: WhereJsonObject<this>;
+    andWhereNotJsonObject: WhereJsonObject<this>;
+
+    whereJsonPath: WhereJsonPath<this>;
+    orWhereJsonPath: WhereJsonPath<this>;
+    andWhereJsonPath: WhereJsonPath<this>;
+
     whereJsonSupersetOf: WhereJsonMethod<this>;
+    andWhereJsonSupersetOf: WhereJsonMethod<this>;
     orWhereJsonSupersetOf: WhereJsonMethod<this>;
     whereJsonNotSupersetOf: WhereJsonMethod<this>;
+    andWhereJsonNotSupersetOf: WhereJsonMethod<this>;
     orWhereJsonNotSupersetOf: WhereJsonMethod<this>;
     whereJsonSubsetOf: WhereJsonMethod<this>;
+    andWhereJsonSubsetOf: WhereJsonMethod<this>;
     orWhereJsonSubsetOf: WhereJsonMethod<this>;
     whereJsonNotSubsetOf: WhereJsonMethod<this>;
+    andWhereJsonNotSubsetOf: WhereJsonMethod<this>;
     orWhereJsonNotSubsetOf: WhereJsonMethod<this>;
     whereJsonIsArray: WhereFieldExpressionMethod<this>;
     orWhereJsonIsArray: WhereFieldExpressionMethod<this>;
@@ -892,6 +991,8 @@ declare namespace Objection {
     with: WithMethod<this>;
     withRecursive: WithMethod<this>;
     withWrapped: WithMethod<this>;
+    withMaterialized: WithMethod<this>;
+    withNotMaterialized: WithMethod<this>;
 
     joinRelated: JoinRelatedMethod<this>;
     innerJoinRelated: JoinRelatedMethod<this>;


### PR DESCRIPTION
_ported from https://github.com/ovos/objection.js/pull/15_

### adjustments for knex v1 and v2

knex v1+ changed the return values when `.returning()` clause is used (affecting postgres), before it returned array of primitive values if only 1 column was selected to be returned (e.g. `[1]` for `.returning('id')`) but now it always returns objects (e.g. `[{ id: 1 }]` for `.returning('id')`).

Slightly reorganized `InsertOperation`, instead of calling `createModels` in `doExecute()` (right after `onRawResult` hook) and having "empty" model instances created there, possibly with undefined / declared default properties which would later overwrite input models in `InsertOperation.onAfter1`, offload the handling to `InsertOperation.onAfter1`, which now uses also `setDatabaseJson`, same as `createModels` function, to be consistent.

Additionally, adjusted `$parseDatabaseJson` in `GraphInsert` integration tests, to only parse boolean values when they are present in `json`.

related change in knex v1.0: https://github.com/knex/knex/pull/4471

### introduced new (or missing) knex querybuilder's methods

to make shapes of both querybuilders as close to each other as possible.
Most of the methods were introduced in knex v1.
- `fromRaw`
- `whereLike`
- `andWhereLike`
- `orWhereLike`
- `whereILike`
- `andWhereILike`
- `orWhereILike`
- `withMaterialized`
- `withNotMaterialized`
- `jsonExtract`
- `jsonSet`
- `jsonInsert`
- `jsonRemove`
- `whereJsonObject`
- `orWhereJsonObject`
- `andWhereJsonObject`
- `whereNotJsonObject`
- `orWhereNotJsonObject`
- `andWhereNotJsonObject`
- `whereJsonPath`
- `orWhereJsonPath`
- `andWhereJsonPath`

and one new `JoinBuilder` method - `andOnJsonPathEquals` (referencing knex's `JoinClause` method of the same name)

related: https://github.com/knex/knex/pull/4859 https://github.com/knex/knex/pull/5044

`whereJson(Not)SupersetOf` / `whereJson(Not)SubsetOf` are now supported by knex >= 1.0, but for now
objection handles them differently and only for postgres.
Changing them to utilize knex methods directly may require a major version bump and upgrade guide.

Added a test for checking JoinBuilder methods to be inline with knex's JoinClause.

Fixed incorrect checking QueryBuilder methods if they are inline with knex's QueryBuilder.

Added typings for new methods.

Bumped knex `peerDependency` from `>=0.95.13` to `>=1.0.1` because of new methods.
