### PR TITLE
update knex-related parts in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What objection.js **doesn't** give you:
 - **Automatic database schema creation and migration from model definitions.**
   For simple things it is useful that the database schema is automatically generated from the model definitions,
   but usually just gets in your way when doing anything non-trivial. Objection.js leaves the schema related things
-  to you. knex has a great [migration tool](http://knexjs.org/#Migrations) that we recommend for this job. Check
+  to you. knex has a great [migration tool](https://knexjs.org/guide/migrations.html) that we recommend for this job. Check
   out the [example project](https://github.com/Vincit/objection.js/tree/master/examples/koa-ts).
 
 The best way to get started is to clone our [example project](https://github.com/Vincit/objection.js/tree/master/examples/koa) and start playing with it. There's also a [typescript version](https://github.com/Vincit/objection.js/tree/master/examples/koa-ts) available.

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,7 +32,7 @@ What objection.js **doesn't** give you:
 - **Automatic database schema creation and migration from model definitions.**
   For simple things it is useful that the database schema is automatically generated from the model definitions,
   but usually just gets in your way when doing anything non-trivial. Objection.js leaves the schema related things
-  to you. knex has a great [migration tool](http://knexjs.org/#Migrations) that we recommend for this job. Check
+  to you. knex has a great [migration tool](https://knexjs.org/guide/migrations.html) that we recommend for this job. Check
   out the [example project](https://github.com/Vincit/objection.js/tree/master/examples/koa-ts).
 
 The best way to get started is to clone our [example project](https://github.com/Vincit/objection.js/tree/master/examples/koa) and start playing with it. There's also a [typescript version](https://github.com/Vincit/objection.js/tree/master/examples/koa-ts) available.

--- a/doc/api/query-builder/README.md
+++ b/doc/api/query-builder/README.md
@@ -2,7 +2,7 @@
 
 `QueryBuilder` is the most important component in objection. Every method that allows you to fetch or modify items in the database returns an instance of the `QueryBuilder`.
 
-`QueryBuilder` is a wrapper around [knex QueryBuilder](http://knexjs.org#Builder). QueryBuilder has all the methods a knex QueryBuilder has and more. While knex QueryBuilder returns plain JavaScript objects, QueryBuilder returns Model subclass instances.
+`QueryBuilder` is a wrapper around [knex QueryBuilder](https://knexjs.org/guide/query-builder.html). QueryBuilder has all the methods a knex QueryBuilder has and more. While knex QueryBuilder returns plain JavaScript objects, QueryBuilder returns Model subclass instances.
 
 QueryBuilder is thenable, meaning that it can be used like a promise. You can `await` a query builder, and it will get executed. You can return query builder from a [then](/api/query-builder/other-methods.html#then) method of a promise and it gets chained just like a normal promise would.
 

--- a/doc/api/query-builder/find-methods.md
+++ b/doc/api/query-builder/find-methods.md
@@ -185,7 +185,7 @@ await Person.query()
 
 ## select()
 
-See [knex documentation](http://knexjs.org/#Builder-select)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#select)
 
 ##### Return value
 
@@ -195,7 +195,7 @@ See [knex documentation](http://knexjs.org/#Builder-select)
 
 ## forUpdate()
 
-See [knex documentation](http://knexjs.org/#Builder-forUpdate)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#forupdate)
 
 ##### Return value
 
@@ -205,7 +205,7 @@ See [knex documentation](http://knexjs.org/#Builder-forUpdate)
 
 ## forShare()
 
-See [knex documentation](http://knexjs.org/#Builder-forShare)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#forshare)
 
 ##### Return value
 
@@ -215,7 +215,7 @@ See [knex documentation](http://knexjs.org/#Builder-forShare)
 
 ## skipLocked()
 
-See [knex documentation](http://knexjs.org/#Builder-skipLocked)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#skiplocked)
 
 ##### Return value
 
@@ -225,7 +225,7 @@ See [knex documentation](http://knexjs.org/#Builder-skipLocked)
 
 ## noWait()
 
-See [knex documentation](http://knexjs.org/#Builder-noWait)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#nowait)
 
 ##### Return value
 
@@ -235,7 +235,7 @@ See [knex documentation](http://knexjs.org/#Builder-noWait)
 
 ## as()
 
-See [knex documentation](http://knexjs.org/#Builder-as)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#as)
 
 ##### Return value
 
@@ -245,7 +245,7 @@ See [knex documentation](http://knexjs.org/#Builder-as)
 
 ## columns()
 
-See [knex documentation](http://knexjs.org/#Builder-columns)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#column)
 
 ##### Return value
 
@@ -255,7 +255,7 @@ See [knex documentation](http://knexjs.org/#Builder-columns)
 
 ## column()
 
-See [knex documentation](http://knexjs.org/#Builder-column)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#column)
 
 ##### Return value
 
@@ -265,7 +265,17 @@ See [knex documentation](http://knexjs.org/#Builder-column)
 
 ## from()
 
-See [knex documentation](http://knexjs.org/#Builder-from)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#from)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## fromRaw()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#fromRaw)
 
 ##### Return value
 
@@ -275,7 +285,7 @@ See [knex documentation](http://knexjs.org/#Builder-from)
 
 ## into()
 
-See [knex documentation](http://knexjs.org/#Builder-into)
+See [knex documentation](https://knexjs.org/guide/query-builder.html)
 
 ##### Return value
 
@@ -285,7 +295,7 @@ See [knex documentation](http://knexjs.org/#Builder-into)
 
 ## with()
 
-See [knex documentation](http://knexjs.org/#Builder-with)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#with)
 
 ##### Return value
 
@@ -295,7 +305,7 @@ See [knex documentation](http://knexjs.org/#Builder-with)
 
 ## withSchema()
 
-See [knex documentation](http://knexjs.org/#Builder-withSchema)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#withschema)
 
 ##### Return value
 
@@ -305,7 +315,7 @@ See [knex documentation](http://knexjs.org/#Builder-withSchema)
 
 ## table()
 
-See [knex documentation](http://knexjs.org/#Builder-table)
+See [knex documentation](https://knexjs.org/guide/query-builder.html)
 
 ##### Return value
 
@@ -315,7 +325,7 @@ See [knex documentation](http://knexjs.org/#Builder-table)
 
 ## distinct()
 
-See [knex documentation](http://knexjs.org/#Builder-distinct)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#distinct)
 
 ##### Return value
 
@@ -325,7 +335,7 @@ See [knex documentation](http://knexjs.org/#Builder-distinct)
 
 ## distinctOn()
 
-See [knex documentation](http://knexjs.org/#Builder-distinctOn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#distincton)
 
 ##### Return value
 
@@ -335,7 +345,7 @@ See [knex documentation](http://knexjs.org/#Builder-distinctOn)
 
 ## where()
 
-See [knex documentation](http://knexjs.org/#Builder-where)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -345,7 +355,7 @@ See [knex documentation](http://knexjs.org/#Builder-where)
 
 ## andWhere()
 
-See [knex documentation](http://knexjs.org/#Builder-where)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -355,7 +365,7 @@ See [knex documentation](http://knexjs.org/#Builder-where)
 
 ## orWhere()
 
-See [knex documentation](http://knexjs.org/#Builder-where)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -365,7 +375,7 @@ See [knex documentation](http://knexjs.org/#Builder-where)
 
 ## whereNot()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNot)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenot)
 
 ##### Return value
 
@@ -375,7 +385,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNot)
 
 ## orWhereNot()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNot)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenot)
 
 ##### Return value
 
@@ -385,7 +395,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNot)
 
 ## whereRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-whereRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#whereraw)
 
 ##### Return value
 
@@ -395,7 +405,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereRaw)
 
 ## whereWrapped()
 
-See [knex documentation](http://knexjs.org/#Builder-wheres)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -405,7 +415,7 @@ See [knex documentation](http://knexjs.org/#Builder-wheres)
 
 ## havingWrapped()
 
-See [knex documentation](http://knexjs.org/#Builder-having)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#having)
 
 ##### Return value
 
@@ -415,7 +425,7 @@ See [knex documentation](http://knexjs.org/#Builder-having)
 
 ## orWhereRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-whereRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#whereraw)
 
 ##### Return value
 
@@ -425,7 +435,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereRaw)
 
 ## whereExists()
 
-See [knex documentation](http://knexjs.org/#Builder-whereExists)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#whereexists)
 
 ##### Return value
 
@@ -435,7 +445,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereExists)
 
 ## orWhereExists()
 
-See [knex documentation](http://knexjs.org/#Builder-whereExists)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#whereexists)
 
 ##### Return value
 
@@ -445,7 +455,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereExists)
 
 ## whereNotExists()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotExists)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotexists)
 
 ##### Return value
 
@@ -455,7 +465,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotExists)
 
 ## orWhereNotExists()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotExists)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotexists)
 
 ##### Return value
 
@@ -465,7 +475,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotExists)
 
 ## whereIn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereIn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherein)
 
 ##### Return value
 
@@ -475,7 +485,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereIn)
 
 ## orWhereIn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereIn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherein)
 
 ##### Return value
 
@@ -485,7 +495,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereIn)
 
 ## whereNotIn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotIn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotin)
 
 ##### Return value
 
@@ -495,7 +505,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotIn)
 
 ## orWhereNotIn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotIn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotin)
 
 ##### Return value
 
@@ -505,7 +515,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotIn)
 
 ## whereNull()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNull)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenull)
 
 ##### Return value
 
@@ -515,7 +525,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNull)
 
 ## orWhereNull()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNull)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenull)
 
 ##### Return value
 
@@ -525,7 +535,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNull)
 
 ## whereNotNull()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotNull)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotnull)
 
 ##### Return value
 
@@ -535,7 +545,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotNull)
 
 ## orWhereNotNull()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotNull)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotnull)
 
 ##### Return value
 
@@ -545,7 +555,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotNull)
 
 ## whereBetween()
 
-See [knex documentation](http://knexjs.org/#Builder-whereBetween)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherebetween)
 
 ##### Return value
 
@@ -555,7 +565,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereBetween)
 
 ## whereNotBetween()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotBetween)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotbetween)
 
 ##### Return value
 
@@ -565,7 +575,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotBetween)
 
 ## orWhereBetween()
 
-See [knex documentation](http://knexjs.org/#Builder-whereBetween)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherebetween)
 
 ##### Return value
 
@@ -575,7 +585,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereBetween)
 
 ## orWhereNotBetween()
 
-See [knex documentation](http://knexjs.org/#Builder-whereNotBetween)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherenotbetween)
 
 ##### Return value
 
@@ -585,7 +595,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereNotBetween)
 
 ## whereColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -595,7 +605,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## andWhereColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -605,7 +615,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## orWhereColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -615,7 +625,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## whereNotColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -625,7 +635,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## andWhereNotColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -635,7 +645,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## orWhereNotColumn()
 
-See [knex documentation](http://knexjs.org/#Builder-whereColumn)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 
 ##### Return value
 
@@ -645,7 +655,7 @@ See [knex documentation](http://knexjs.org/#Builder-whereColumn)
 
 ## groupBy()
 
-See [knex documentation](http://knexjs.org/#Builder-groupBy)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#groupby)
 
 ##### Return value
 
@@ -655,7 +665,7 @@ See [knex documentation](http://knexjs.org/#Builder-groupBy)
 
 ## groupByRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-groupByRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#groupbyraw)
 
 ##### Return value
 
@@ -665,7 +675,7 @@ See [knex documentation](http://knexjs.org/#Builder-groupByRaw)
 
 ## orderBy()
 
-See [knex documentation](http://knexjs.org/#Builder-orderBy)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#orderby)
 
 ##### Return value
 
@@ -675,7 +685,7 @@ See [knex documentation](http://knexjs.org/#Builder-orderBy)
 
 ## orderByRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-orderByRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#orderbyraw)
 
 ##### Return value
 
@@ -685,7 +695,7 @@ See [knex documentation](http://knexjs.org/#Builder-orderByRaw)
 
 ## union()
 
-See [knex documentation](http://knexjs.org/#Builder-union)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#union)
 
 ##### Return value
 
@@ -695,7 +705,7 @@ See [knex documentation](http://knexjs.org/#Builder-union)
 
 ## unionAll()
 
-See [knex documentation](http://knexjs.org/#Builder-unionAll)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#unionall)
 
 ##### Return value
 
@@ -705,7 +715,7 @@ See [knex documentation](http://knexjs.org/#Builder-unionAll)
 
 ## intersect()
 
-See [knex documentation](http://knexjs.org/#Builder-unionAll)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#intersect)
 
 ##### Return value
 
@@ -716,7 +726,7 @@ See [knex documentation](http://knexjs.org/#Builder-unionAll)
 
 ## having()
 
-See [knex documentation](http://knexjs.org/#Builder-having)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#having)
 
 ##### Return value
 
@@ -726,7 +736,7 @@ See [knex documentation](http://knexjs.org/#Builder-having)
 
 ## havingRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-havingRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#havingraw)
 
 ##### Return value
 
@@ -736,7 +746,7 @@ See [knex documentation](http://knexjs.org/#Builder-havingRaw)
 
 ## orHaving()
 
-See [knex documentation](http://knexjs.org/#Builder-having)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#having)
 
 ##### Return value
 
@@ -746,7 +756,7 @@ See [knex documentation](http://knexjs.org/#Builder-having)
 
 ## orHavingRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-havingRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#havingraw)
 
 ##### Return value
 
@@ -756,7 +766,7 @@ See [knex documentation](http://knexjs.org/#Builder-havingRaw)
 
 ## offset()
 
-See [knex documentation](http://knexjs.org/#Builder-offset)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#offset)
 
 ##### Return value
 
@@ -766,7 +776,7 @@ See [knex documentation](http://knexjs.org/#Builder-offset)
 
 ## limit()
 
-See [knex documentation](http://knexjs.org/#Builder-limit)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#limit)
 
 ##### Return value
 
@@ -776,7 +786,7 @@ See [knex documentation](http://knexjs.org/#Builder-limit)
 
 ## count()
 
-See [knex documentation](http://knexjs.org/#Builder-count)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#count)
 
 Also see the [resultSize](/api/query-builder/other-methods.md#resultsize) method for a cleaner way to just get the number of rows a query would create.
 
@@ -788,7 +798,7 @@ Also see the [resultSize](/api/query-builder/other-methods.md#resultsize) method
 
 ## countDistinct()
 
-See [knex documentation](http://knexjs.org/#Builder-count)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#count)
 
 ##### Return value
 
@@ -798,7 +808,7 @@ See [knex documentation](http://knexjs.org/#Builder-count)
 
 ## min()
 
-See [knex documentation](http://knexjs.org/#Builder-min)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#min)
 
 ##### Return value
 
@@ -808,7 +818,7 @@ See [knex documentation](http://knexjs.org/#Builder-min)
 
 ## max()
 
-See [knex documentation](http://knexjs.org/#Builder-max)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#max)
 
 ##### Return value
 
@@ -818,7 +828,7 @@ See [knex documentation](http://knexjs.org/#Builder-max)
 
 ## sum()
 
-See [knex documentation](http://knexjs.org/#Builder-sum)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#sum)
 
 ##### Return value
 
@@ -828,7 +838,7 @@ See [knex documentation](http://knexjs.org/#Builder-sum)
 
 ## avg()
 
-See [knex documentation](http://knexjs.org/#Builder-avg)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#avg)
 
 ##### Return value
 
@@ -838,7 +848,7 @@ See [knex documentation](http://knexjs.org/#Builder-avg)
 
 ## avgDistinct()
 
-See [knex documentation](http://knexjs.org/#Builder-avg)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#avg)
 
 ##### Return value
 
@@ -848,7 +858,7 @@ See [knex documentation](http://knexjs.org/#Builder-avg)
 
 ## returning()
 
-See [knex documentation](http://knexjs.org/#Builder-returning)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#returning)
 
 ##### Return value
 
@@ -858,7 +868,7 @@ See [knex documentation](http://knexjs.org/#Builder-returning)
 
 ## columnInfo()
 
-See [knex documentation](http://knexjs.org/#Builder-columnInfo)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#columninfo)
 
 ##### Return value
 

--- a/doc/api/query-builder/find-methods.md
+++ b/doc/api/query-builder/find-methods.md
@@ -303,6 +303,26 @@ See [knex documentation](https://knexjs.org/guide/query-builder.html#with)
 | ----------------------------------- | ---------------------------------- |
 | [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
 
+## withMaterialized()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#withmaterialized)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## withNotMaterialized()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#withnotmaterialized)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
 ## withSchema()
 
 See [knex documentation](https://knexjs.org/guide/query-builder.html#withschema)
@@ -653,6 +673,26 @@ See [knex documentation](https://knexjs.org/guide/query-builder.html#where)
 | ----------------------------------- | ---------------------------------- |
 | [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
 
+## whereLike()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherelike)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## whereILike()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#whereilike)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
 ## groupBy()
 
 See [knex documentation](https://knexjs.org/guide/query-builder.html#groupby)
@@ -940,6 +980,76 @@ builder.whereInComposite('a', [1, 3, 1]);
 ```js
 builder.whereInComposite(['a', 'b'], SomeModel.query().select('a', 'b'));
 ```
+
+## jsonExtract()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#jsonextract)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## jsonSet()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#jsonset)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## jsonInsert()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#jsoninsert)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## jsonRemove()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#jsonremove)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## whereJsonObject()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherejsonobject)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## whereNotJsonObject()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherejsonobject)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
+## whereJsonPath()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#wherejsonpath)
+
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
 
 ## whereJsonSupersetOf()
 

--- a/doc/api/query-builder/join-methods.md
+++ b/doc/api/query-builder/join-methods.md
@@ -122,7 +122,7 @@ Full outer join version of the [joinRelated](/api/query-builder/join-methods.htm
 
 ## join()
 
-See [knex documentation](http://knexjs.org/#Builder-join)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#join)
 
 ##### Return value
 
@@ -132,7 +132,7 @@ See [knex documentation](http://knexjs.org/#Builder-join)
 
 ## joinRaw()
 
-See [knex documentation](http://knexjs.org/#Builder-joinRaw)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#joinraw)
 
 ##### Return value
 
@@ -142,7 +142,7 @@ See [knex documentation](http://knexjs.org/#Builder-joinRaw)
 
 ## innerJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-innerJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#innerjoin)
 
 ##### Return value
 
@@ -152,7 +152,7 @@ See [knex documentation](http://knexjs.org/#Builder-innerJoin)
 
 ## leftJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-leftJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#leftjoin)
 
 ##### Return value
 
@@ -162,7 +162,7 @@ See [knex documentation](http://knexjs.org/#Builder-leftJoin)
 
 ## leftOuterJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-leftOuterJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#leftouterjoin)
 
 ##### Return value
 
@@ -172,7 +172,7 @@ See [knex documentation](http://knexjs.org/#Builder-leftOuterJoin)
 
 ## rightJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-rightJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#rightjoin)
 
 ##### Return value
 
@@ -182,7 +182,7 @@ See [knex documentation](http://knexjs.org/#Builder-rightJoin)
 
 ## rightOuterJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-rightOuterJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#rightouterjoin)
 
 ##### Return value
 
@@ -192,7 +192,7 @@ See [knex documentation](http://knexjs.org/#Builder-rightOuterJoin)
 
 ## outerJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-outerJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#fullouterjoin)
 
 ##### Return value
 
@@ -202,7 +202,7 @@ See [knex documentation](http://knexjs.org/#Builder-outerJoin)
 
 ## fullOuterJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-fullOuterJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#fullouterjoin)
 
 ##### Return value
 
@@ -212,7 +212,7 @@ See [knex documentation](http://knexjs.org/#Builder-fullOuterJoin)
 
 ## crossJoin()
 
-See [knex documentation](http://knexjs.org/#Builder-crossJoin)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#crossjoin)
 
 ##### Return value
 

--- a/doc/api/query-builder/mutate-methods.md
+++ b/doc/api/query-builder/mutate-methods.md
@@ -766,7 +766,7 @@ console.log(
 
 ## increment()
 
-See [knex documentation](http://knexjs.org/#Builder-increment)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#increment)
 
 ##### Return value
 
@@ -776,7 +776,7 @@ See [knex documentation](http://knexjs.org/#Builder-increment)
 
 ## decrement()
 
-See [knex documentation](http://knexjs.org/#Builder-decrement)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#decrement)
 
 ##### Return value
 
@@ -786,7 +786,7 @@ See [knex documentation](http://knexjs.org/#Builder-decrement)
 
 ## truncate()
 
-See [knex documentation](http://knexjs.org/#Builder-truncate)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#truncate)
 
 ##### Return value
 
@@ -796,7 +796,7 @@ See [knex documentation](http://knexjs.org/#Builder-truncate)
 
 ## onConflict()
 
-See [knex documentation](http://knexjs.org/#Builder-onConflict)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#onconflict)
 
 ##### Return value
 
@@ -806,7 +806,7 @@ See [knex documentation](http://knexjs.org/#Builder-onConflict)
 
 ## ignore()
 
-See [knex documentation](http://knexjs.org/#Builder-ignore)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#ignore)
 
 ##### Return value
 
@@ -816,7 +816,7 @@ See [knex documentation](http://knexjs.org/#Builder-ignore)
 
 ## merge()
 
-See [knex documentation](http://knexjs.org/#Builder-merge)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#merge)
 
 ##### Return value
 

--- a/doc/api/query-builder/other-methods.md
+++ b/doc/api/query-builder/other-methods.md
@@ -4,7 +4,7 @@
 
 Chaining this method to any query will print all the executed SQL to console.
 
-See [knex documentation](http://knexjs.org/#Builder-debug)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#debug)
 
 ##### Return value
 
@@ -1010,7 +1010,7 @@ try {
 
 ## timeout()
 
-See [knex documentation](http://knexjs.org/#Builder-timeout)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#debug)
 
 ##### Return value
 
@@ -1020,7 +1020,7 @@ See [knex documentation](http://knexjs.org/#Builder-timeout)
 
 ## connection()
 
-See [knex documentation](http://knexjs.org/#Builder-connection)
+See [knex documentation](https://knexjs.org/guide/query-builder.html#connection)
 
 ##### Return value
 
@@ -1030,7 +1030,7 @@ See [knex documentation](http://knexjs.org/#Builder-connection)
 
 ## modify()
 
-Works like `knex`'s [modify](http://knexjs.org/#Builder-modify) function but in addition you can specify a [modifier](/api/model/static-properties.html#static-modifiers) by providing modifier names.
+Works like `knex`'s [modify](https://knexjs.org/guide/query-builder.html#modify) function but in addition you can specify a [modifier](/api/model/static-properties.html#static-modifiers) by providing modifier names.
 
 See the [modifier](/recipes/modifiers.html) recipe for examples of the things you can do with modifiers.
 

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-To use objection.js all you need to do is [initialize knex](http://knexjs.org/#Installation-node) and give the created knex instance to objection.js using [Model.knex(knex)](/api/model/static-methods.html#static-knex). Doing this installs the knex instance globally for all models (even the ones that have not been created yet). If you need to use multiple databases check out our [multi-tenancy recipe](/recipes/multitenancy-using-multiple-databases.html).
+To use objection.js all you need to do is [initialize knex](https://knexjs.org/guide/#node-js) and give the created knex instance to objection.js using [Model.knex(knex)](/api/model/static-methods.html#static-knex). Doing this installs the knex instance globally for all models (even the ones that have not been created yet). If you need to use multiple databases check out our [multi-tenancy recipe](/recipes/multitenancy-using-multiple-databases.html).
 
 The next step is to create some migrations and models and start using objection.js. The best way to get started is to check out one of our example projects:
 

--- a/doc/guide/models.md
+++ b/doc/guide/models.md
@@ -8,7 +8,7 @@ Each model must have an identifier column. The identifier column name can be set
 
 In objection, all configuration is done through [Model](/api/model/) classes and there is no global configuration or state. There is no "objection instance". This allows you to create isolated components and for example to use multiple different databases with different configurations in one app. Most of the time you want the same configuration for all models and a good pattern is to create a `BaseModel` class and inherit all your models from that. You can then add all shared configuration to `BaseModel`. See the static properties in [API Reference / Model](/api/model/static-properties.html#static-tablename) section for all available configuration options.
 
-Note that in addition to `idColumn`, you don't define properties, indexes or anything else related to database schema in the model. In objection, database schema is considered a separate concern and should be handled using [migrations](https://knexjs.org/#Migrations). The reasoning is that every non-trivial project will need migrations anyway. Managing the schema in two places (model and migrations) only makes things more complex in the long run.
+Note that in addition to `idColumn`, you don't define properties, indexes or anything else related to database schema in the model. In objection, database schema is considered a separate concern and should be handled using [migrations](https://knexjs.org/guide/migrations.html). The reasoning is that every non-trivial project will need migrations anyway. Managing the schema in two places (model and migrations) only makes things more complex in the long run.
 
 ## Examples
 

--- a/doc/guide/query-examples.md
+++ b/doc/guide/query-examples.md
@@ -6,7 +6,7 @@ sidebarDepth: 3
 
 The `Person` model used in the examples is defined [here](/guide/models.html#examples).
 
-All queries are started with one of the [Model](/api/model/) methods [query](/api/model/static-methods.html#static-query), [\$query](/api/model/instance-methods.html#query), [relatedQuery](/api/model/static-methods.html#static-relatedquery) or [\$relatedQuery](/api/model/instance-methods.html#relatedquery). All these methods return a [QueryBuilder](/api/query-builder/) instance that can be used just like a [knex QueryBuilder](http://knexjs.org/#Builder) but they also have a bunch of methods added by objection.
+All queries are started with one of the [Model](/api/model/) methods [query](/api/model/static-methods.html#static-query), [\$query](/api/model/instance-methods.html#query), [relatedQuery](/api/model/static-methods.html#static-relatedquery) or [\$relatedQuery](/api/model/instance-methods.html#relatedquery). All these methods return a [QueryBuilder](/api/query-builder/) instance that can be used just like a [knex QueryBuilder](https://knexjs.org/guide/query-builder.html) but they also have a bunch of methods added by objection.
 
 Note that you can chain [debug()](/api/query-builder/other-methods.html#debug) to any query to get the executed SQL printed to console.
 

--- a/doc/guide/transactions.md
+++ b/doc/guide/transactions.md
@@ -21,7 +21,7 @@ try {
 }
 ```
 
-The first argument is a callback that gets called with the transaction object as an argument once the transaction has been successfully started. The transaction object is actually just a [knex transaction object](http://knexjs.org/#Transactions) and you can start the transaction just as well using [knex.transaction](http://knexjs.org/#Transactions) function.
+The first argument is a callback that gets called with the transaction object as an argument once the transaction has been successfully started. The transaction object is actually just a [knex transaction object](https://knexjs.org/guide/transactions.html) and you can start the transaction just as well using [knex.transaction](http://knexjs.org/#Transactions) function.
 
 The transaction is committed if the promise returned from the callback is resolved successfully. If the returned Promise is rejected or an error is thrown inside the callback the transaction is rolled back.
 

--- a/doc/recipes/joins.md
+++ b/doc/recipes/joins.md
@@ -1,6 +1,6 @@
 # Joins
 
-Again, [do as you would with a knex query builder](http://knexjs.org/#Builder-join):
+Again, [do as you would with a knex query builder](https://knexjs.org/guide/query-builder.html#join):
 
 ```js
 const people = await Person.query()

--- a/doc/recipes/raw-queries.md
+++ b/doc/recipes/raw-queries.md
@@ -1,8 +1,8 @@
 # Raw queries
 
-To mix raw SQL with queries, use the [raw](/api/objection/#raw) function from the main module. [raw](/api/objection/#raw) works just like the [knex's raw method](http://knexjs.org/#Raw) but in addition, supports objection queries, [raw](/api/objection/#raw), [ref](/api/objection/#ref), [val](/api/objection/#val) and all other objection types. You can also use [knex.raw()](http://knexjs.org/#Raw).
+To mix raw SQL with queries, use the [raw](/api/objection/#raw) function from the main module. [raw](/api/objection/#raw) works just like the [knex's raw method](https://knexjs.org/guide/raw.html) but in addition, supports objection queries, [raw](/api/objection/#raw), [ref](/api/objection/#ref), [val](/api/objection/#val) and all other objection types. You can also use [knex.raw()](https://knexjs.org/guide/raw.html).
 
-[raw](/api/objection/#raw) is handy when you want to mix SQL in objection queries, but if you want to fire off a completely custom query, you need to use [knex.raw](http://knexjs.org/#Raw).
+[raw](/api/objection/#raw) is handy when you want to mix SQL in objection queries, but if you want to fire off a completely custom query, you need to use [knex.raw](https://knexjs.org/guide/raw.html).
 
 There are also some helper methods such as [whereRaw](/api/query-builder/find-methods.html#whereraw) in the [QueryBuilder](/api/query-builder/).
 

--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -997,7 +997,7 @@ const relQueryResult10: PromiseLike<Movie[]> =
   Person.relatedQuery<Movie>('nonExistentRelation').for(1);
 
 /**
- * http://knexjs.org/#Builder-count
+ * https://knexjs.org/guide/query-builder.html#count
  */
 Person.query().count('active', { as: 'a' });
 Person.query().count('active as a');


### PR DESCRIPTION
- update existing links to knex docs
- update docs to include knex v1+ methods added in #2372

docs might still be not in sync with knex, probably not all existing methods are documented, but I could not spend more time on it. A tool to automatically check them and synchronize would be handy 😉