### PR TITLE
Add support for `nulls` in orderBy method

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -4,13 +4,13 @@ import * as objection from '../../';
 import {
   DBError,
   fn,
-  val,
+  QueryBuilder,
   raw,
   ref,
-  RelationMappings,
   RelationMapping,
-  QueryBuilder,
+  RelationMappings,
   StaticHookArguments,
+  val,
 } from '../../';
 
 // This file exercises the Objection.js typings.
@@ -1144,7 +1144,7 @@ const whereDelRetFirstWhere: PromiseLike<Person | undefined> = qb
 const orderByColumn: PromiseLike<Person[]> = qb.orderBy('firstName', 'asc');
 const orderByColumns: PromiseLike<Person[]> = qb.orderBy([
   'email',
-  { column: 'firstName', order: 'asc' },
+  { column: 'firstName', order: 'asc', nulls: 'first' },
   { column: 'lastName' },
 ]);
 

--- a/tests/ts/query-builder-api/find-methods.ts
+++ b/tests/ts/query-builder-api/find-methods.ts
@@ -157,6 +157,7 @@ import { Person } from '../fixtures/person';
   await Person.query().orderBy('email');
   await Person.query().orderBy('email', 'ASC');
   await Person.query().orderBy('email', 'desc');
+  await Person.query().orderBy('email', 'desc', 'last');
   await Person.query().orderByRaw('? ASC', ['email']);
   await Person.query().orderByRaw('email desc');
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -163,6 +163,7 @@ declare namespace Objection {
     | string[]
     | Record<string, Expression<PrimitiveValue>>;
   type OrderByDirection = 'asc' | 'desc' | 'ASC' | 'DESC';
+  type OrderByNulls = 'first' | 'last';
 
   interface Modifiers<QB extends AnyQueryBuilder = AnyQueryBuilder> {
     [key: string]: Modifier<QB>;
@@ -634,12 +635,13 @@ declare namespace Objection {
   interface OrderByDescriptor {
     column: ColumnRef;
     order?: OrderByDirection;
+    nulls?: OrderByNulls;
   }
 
   type ColumnRefOrOrderByDescriptor = ColumnRef | OrderByDescriptor;
 
   interface OrderByMethod<QB extends AnyQueryBuilder> {
-    (column: ColumnRef, order?: OrderByDirection): QB;
+    (column: ColumnRef, order?: OrderByDirection, nulls?: OrderByNulls): QB;
     (columns: ColumnRefOrOrderByDescriptor[]): QB;
   }
 


### PR DESCRIPTION
I would like to submit a pull request for the following changes:

Adding `nulls` type to the orderBy method, which is currently available in Knex, fixing the issue #2332.

These changes aim to improve the functionality and reliability of the codebase. Please let me know if there are any concerns or suggestions regarding this pull request.

Thank you for your consideration.

