### PR TITLE
Typings: Add knex() method type to QueryBuilder

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1111,6 +1111,7 @@ declare namespace Objection {
     columnInfo: ColumnInfoMethod<this>;
 
     toKnexQuery<T extends {} = ModelObject<M>>(): Knex.QueryBuilder<T, T[]>;
+    knex(knex?: Knex): Knex;
     clone(): this;
 
     page(page: number, pageSize: number): PageQueryBuilder<this>;


### PR DESCRIPTION
Objection.js allows us to get Knex instance from QueryBuilder by using `.knex()` method like this:

```javascript
await ModelName.query(trx).knex().raw(query);
```

Source code: https://github.com/Vincit/objection.js/blob/master/lib/queryBuilder/QueryBuilderOperationSupport.js#L194

But this method is not defined in types definitions. Thus TypeScript shows an error like `Property 'knex' does not exist on type 'QueryBuilder<ModelName, ModelName[]>'` when using the above code.

This PR adds `.knex()` method definition to QueryBuilder types.