### PR TITLE
Generic constructor type.

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1417,9 +1417,9 @@ declare namespace Objection {
     table?: string;
   }
 
-  export interface Constructor<T> {
-    new (): T;
-  }
+  export type Constructor<TResult, TParams extends any[] = any[]> = new (
+    ...params: TParams
+  ) => TResult;
 
   export interface ModelConstructor<M extends Model> extends Constructor<M> {}
 


### PR DESCRIPTION
```
import * as O from 'objection';

export const TestMixin = <M extends O.ModelClass<O.Model>>(Model: M) =>
  class extends Model {
    additionalProperty: string;

    static get modifiers() {
      return {
        ...super.modifiers,
        additionalModifier: <QB extends O.QueryBuilder<O.Model>>(qb: QB) => qb.where({ id: 0 }),
      };
    }
  };
```
fails with error
`error TS2545: A mixin class must have a constructor with a single rest parameter of type 'any[]'.` for Typescript 4.8.4.

With this fix, it compiles successfully.
This also resolves https://github.com/Vincit/objection.js/issues/625 for me.