### PR TITLE
fix typings for PartialModelGraph and nullable fields

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -376,7 +376,7 @@ class Animal extends objection.Model {
   // prettier-ignore
   species!: string;
   name?: string;
-  owner?: Person;
+  owner?: Person | null;
 
   // Tests the ColumnNameMappers interface.
   static columnNameMappers = {

--- a/tests/ts/query-examples/graph-upserts.ts
+++ b/tests/ts/query-examples/graph-upserts.ts
@@ -1,5 +1,6 @@
 import { UpsertGraphOptions } from '../../../typings/objection';
 import { Person } from '../fixtures/person';
+import { Animal } from '../fixtures/animal';
 
 (async () => {
   await Person.query().upsertGraph({
@@ -185,4 +186,13 @@ import { Person } from '../fixtures/person';
     },
     options
   );
+
+  // save an animal with only first name of the owner
+  // owner's type is defined as nullable with `Person | null` - and partial graph should still be accepted
+  // https://github.com/Vincit/objection.js/pull/2404
+  await Animal.query().upsertGraph({
+    species: 'Dog',
+    name: 'Wolfgang',
+    owner: { firstName: 'Jennifer' },
+  });
 })();

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -225,15 +225,19 @@ declare namespace Objection {
    */
   type PartialModelGraph<M, T = M & GraphParameters> = T extends any
     ? {
-        [K in DataPropertyNames<T>]?: Defined<T[K]> extends Model
-          ? PartialModelGraph<Defined<T[K]>>
-          : Defined<T[K]> extends Array<infer I>
-          ? I extends Model
-            ? PartialModelGraph<I>[]
-            : Expression<T[K]>
-          : Expression<T[K]>;
+        [K in DataPropertyNames<T>]?: null extends T[K]
+          ? PartialModelGraphField<NonNullable<T[K]>> | null // handle nullable BelongsToOneRelations
+          : PartialModelGraphField<T[K]>;
       }
     : never;
+
+  type PartialModelGraphField<F> = Defined<F> extends Model
+    ? PartialModelGraph<Defined<F>>
+    : Defined<F> extends Array<infer I>
+      ? I extends Model
+        ? PartialModelGraph<I>[]
+        : Expression<F>
+      : Expression<F>;
 
   /**
    * Extracts the property names (excluding relations) of a model class.


### PR DESCRIPTION
_ported from https://github.com/ovos/objection.js/pull/16 and adjusted for a typescript perf workaround which landed in https://github.com/Vincit/objection.js/commit/2cefc7735a67a6a840952c407d2a4589cc4d77ba_

Handle `| null` unions properly. (e.g. for nullable `BelongsToOneRelations`).

Before `PartialModelGraph` was converting `field: Model | null;` to `field?: Expression<Model | null>`, and typescript throws errors for graphs with partial sub-graphs for those nullable relations. (expecting full instance of the model class)
Now it converts it properly to `field?: PartialModelGraph<Model> | null` 🎉

fixes the issue mentioned in the last paragraph of the https://github.com/Vincit/objection.js/issues/1774#issuecomment-930678212 by @jeremy-w