### PR TITLE
fix for WrapMysqlModifySubqueryTransformation when using join builder

### DIFF
--- a/lib/queryBuilder/transformations/WrapMysqlModifySubqueryTransformation.js
+++ b/lib/queryBuilder/transformations/WrapMysqlModifySubqueryTransformation.js
@@ -2,6 +2,8 @@
 
 const { QueryTransformation } = require('./QueryTransformation');
 const { isMySql } = require('../../utils/knexUtils');
+const { once } = require('../../utils/objectUtils');
+const getJoinBuilder = once(() => require('../JoinBuilder').JoinBuilder);
 
 /**
  * Mysql doesn't allow queries like this:
@@ -27,6 +29,13 @@ class WrapMysqlModifySubqueryTransformation extends QueryTransformation {
 
     // This transformation only applies to MySQL.
     if (!isMySql(knex)) {
+      return query;
+    }
+
+    // This transformation should not apply to join builder, otherwise it causes:
+    // "TypeError: parentQuery.isUpdate is not a function"
+    const JoinBuilder = getJoinBuilder();
+    if (parentQuery instanceof JoinBuilder) {
       return query;
     }
 


### PR DESCRIPTION
_ported from https://github.com/ovos/objection.js/pull/10_

Fixes error where `.onIn()`/`.andOnIn()` causes:
`TypeError: parentQuery.isUpdate is not a function`

This happens when we provide `.onIn()` with an objection query.

```typescript
BlogPost.query(db)
  .alias('post')
  .innerJoin('post.comment', (join) => {
    join.onIn(
      'comment.author_id',
      Author.query(db).where('active', true)
    );
  });
```

Since `WrapMysqlModifySubqueryTransformation` does not make sense for join query, we simply skip it for `JoinBuilder`.