### PR TITLE
expand allowed types for tableRefFor and tableNameFor

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -833,6 +833,7 @@ const modelFromQuery = qb.modelClass();
 const knexQuery = qb.toKnexQuery().toSQL();
 const tableName: string = qb.tableNameFor(Person);
 const tableRef: string = qb.tableRefFor(Person);
+const tableRefModelClass: string = qb.tableRefFor(modelFromQuery);
 
 function noop() {
   // no-op

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -690,7 +690,7 @@ declare namespace Objection {
   }
 
   interface TableRefForMethod {
-    (modelClass: typeof Model): string;
+    (modelClass: ModelClass<Model> | typeof Model): string;
   }
 
   interface AliasForMethod<QB extends AnyQueryBuilder> {


### PR DESCRIPTION
_ported from https://github.com/ovos/objection.js/pull/9_

It fixes:
```
TS2345: Argument of type 'ModelClass<any>' is not assignable to parameter of type 'typeof Model'.
```


for cases like:
```typescript
query.tableRefFor(query.modelClass());
```