### PR TITLE
CI: update Node versions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds Node.js 18.x & 20.x to version matrix.

18 being the latest LTS release & 20 being "current" release.

For successful run of the pipeline, see [the PR in the fork](https://github.com/stscoundrel/objection.js/pull/1)