### PR TITLE
Remove deprecated $afterGet hook

### DIFF
--- a/lib/model/Model.js
+++ b/lib/model/Model.js
@@ -172,11 +172,6 @@ class Model {
     // Do nothing by default.
   }
 
-  // TODO: Deprecate & remove
-  $afterGet(queryContext) {
-    // Do nothing by default.
-  }
-
   $afterFind(queryContext) {
     // Do nothing by default.
   }

--- a/lib/queryBuilder/operations/FindOperation.js
+++ b/lib/queryBuilder/operations/FindOperation.js
@@ -154,8 +154,6 @@ function doCallAfterFind(ctx, model, result) {
 function getAfterFindHook(model) {
   if (model.$afterFind !== model.$objectionModelClass.prototype.$afterFind) {
     return model.$afterFind;
-  } else if (model.$afterGet !== model.$objectionModelClass.prototype.$afterGet) {
-    return model.$afterGet;
   } else {
     return null;
   }

--- a/tests/integration/find.js
+++ b/tests/integration/find.js
@@ -120,7 +120,7 @@ module.exports = (session) => {
             .select('model2.id_col', 'model2_prop2')
             .then((models) => {
               expect(models[0]).to.be.a(Model2);
-              // Test that only the selected columns (and stuff set by the $afterGet hook)  were returned.
+              // Test that only the selected columns (and stuff set by the $afterFind hook)  were returned.
               expect(_.uniq(_.flattenDeep(_.map(models, _.keys))).sort()).to.eql([
                 '$afterFindCalled',
                 'idCol',

--- a/tests/unit/queryBuilder/QueryBuilder.js
+++ b/tests/unit/queryBuilder/QueryBuilder.js
@@ -1253,8 +1253,8 @@ describe('QueryBuilder', () => {
       this.c = 'beforeUpdate';
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     let model = TestModel.fromJson({ a: 10, b: 'test' });
@@ -1278,8 +1278,8 @@ describe('QueryBuilder', () => {
       });
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     let model = TestModel.fromJson({ a: 10, b: 'test' });
@@ -1300,8 +1300,8 @@ describe('QueryBuilder', () => {
       this.c = 'beforeUpdate';
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     let model = TestModel.fromJson({ a: 10, b: 'test' });
@@ -1325,8 +1325,8 @@ describe('QueryBuilder', () => {
       });
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     let model = TestModel.fromJson({ a: 10, b: 'test' });
@@ -1347,8 +1347,8 @@ describe('QueryBuilder', () => {
       this.c = 'beforeInsert';
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     QueryBuilder.forClass(TestModel)
@@ -1371,8 +1371,8 @@ describe('QueryBuilder', () => {
       });
     };
 
-    TestModel.prototype.$afterGet = function () {
-      throw new Error('$afterGet should not be called');
+    TestModel.prototype.$afterFind = function () {
+      throw new Error('$afterFind should not be called');
     };
 
     QueryBuilder.forClass(TestModel)
@@ -1387,7 +1387,7 @@ describe('QueryBuilder', () => {
       .catch(done);
   });
 
-  it('should call $afterGet on the model if no write operation is specified', (done) => {
+  it('should call $afterFind on the model if no write operation is specified', (done) => {
     mockKnexQueryResults = [
       [
         {
@@ -1399,7 +1399,7 @@ describe('QueryBuilder', () => {
       ],
     ];
 
-    TestModel.prototype.$afterGet = function (context) {
+    TestModel.prototype.$afterFind = function (context) {
       this.b = this.a * 2 + context.x;
     };
 
@@ -1423,7 +1423,7 @@ describe('QueryBuilder', () => {
       .catch(done);
   });
 
-  it('should call $afterGet on the model if no write operation is specified (async)', (done) => {
+  it('should call $afterFind on the model if no write operation is specified (async)', (done) => {
     mockKnexQueryResults = [
       [
         {
@@ -1435,7 +1435,7 @@ describe('QueryBuilder', () => {
       ],
     ];
 
-    TestModel.prototype.$afterGet = function (context) {
+    TestModel.prototype.$afterFind = function (context) {
       let self = this;
       return Bluebird.delay(10).then(() => {
         self.b = self.a * 2 + context.x;
@@ -1462,7 +1462,7 @@ describe('QueryBuilder', () => {
       .catch(done);
   });
 
-  it('should call $afterGet before any `runAfter` hooks', (done) => {
+  it('should call $afterFind before any `runAfter` hooks', (done) => {
     mockKnexQueryResults = [
       [
         {
@@ -1474,7 +1474,7 @@ describe('QueryBuilder', () => {
       ],
     ];
 
-    TestModel.prototype.$afterGet = function (context) {
+    TestModel.prototype.$afterFind = function (context) {
       let self = this;
       return Bluebird.delay(10).then(() => {
         self.b = self.a * 2 + context.x;
@@ -2249,13 +2249,13 @@ describe('QueryBuilder', () => {
         .catch(done);
     });
 
-    it('$afterGet should be called after relations have been fetched', (done) => {
+    it('$afterFind should be called after relations have been fetched', (done) => {
       class M1 extends Model {
         static get tableName() {
           return 'M1';
         }
 
-        $afterGet() {
+        $afterFind() {
           this.ids = _.map(this.someRel, 'id');
         }
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1677,7 +1677,6 @@ declare namespace Objection {
     $afterInsert(queryContext: QueryContext): Promise<any> | void;
     $afterUpdate(opt: ModelOptions, queryContext: QueryContext): Promise<any> | void;
     $beforeUpdate(opt: ModelOptions, queryContext: QueryContext): Promise<any> | void;
-    $afterGet(queryContext: QueryContext): Promise<any> | void;
     $afterFind(queryContext: QueryContext): Promise<any> | void;
     $beforeDelete(queryContext: QueryContext): Promise<any> | void;
     $afterDelete(queryContext: QueryContext): Promise<any> | void;


### PR DESCRIPTION
@koskimas wrote this 4 years ago and it's not mentioned anywhere in the docs:

```js
// TODO: Deprecate & remove
$afterGet(queryContext) {
  // Do nothing by default.
}
```

I think it's time to remove it.