### PR TITLE
Fix typings for Model.columnNameToPropertyName and Model.propertyNameToColumnName static methods

### DIFF
--- a/doc/release-notes/changelog.md
+++ b/doc/release-notes/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.4
+
+### What's new
+
+- Fix `upsertGraph()` `$beforeUpdate()` calls on empty relates [#2605](https://github.com/Vincit/objection.js/issues/2605)
+- Don't call `onError()` with internal exceptions [#2603](https://github.com/Vincit/objection.js/issues/2603)
+- Remove docs and typings for nonexistent `$pick()`
+- Make `$omitFromJson()` + `$omitFromDatabaseJson()` compatible with old `$omit()` syntax
+ 
 ## 3.1.3
 
 ### What's new

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "objection",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "objection",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "Mikael Lepistö <mikael.lepisto@vincit.com> (https://github.com/elhigu)",
     "Matthew McEachen <matthew-objection@photostructure.com> (https://github.com/mceachen)",
     "Jürg Lehni <juerg@scratchdisk.com> (https://github.com/lehni)",
-    "Igor Savin <kibertoad@gmail.com> (https://github.com/kibertoad)",
-    "Guillaume Robin<robinguillaume.pro@gmail.com> (https://github.com/cesumilo)"
+    "Igor Savin <kibertoad@gmail.com> (https://github.com/kibertoad)"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Mikael Lepistö <mikael.lepisto@vincit.com> (https://github.com/elhigu)",
     "Matthew McEachen <matthew-objection@photostructure.com> (https://github.com/mceachen)",
     "Jürg Lehni <juerg@scratchdisk.com> (https://github.com/lehni)",
-    "Igor Savin <kibertoad@gmail.com> (https://github.com/kibertoad)"
+    "Igor Savin <kibertoad@gmail.com> (https://github.com/kibertoad)",
+    "Guillaume Robin<robinguillaume.pro@gmail.com> (https://github.com/cesumilo)"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objection",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "An SQL-friendly ORM for Node.js",
   "main": "lib/objection.js",
   "license": "MIT",

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1473,6 +1473,9 @@ declare namespace Objection {
     fromJson(json: object, opt?: ModelOptions): M;
     fromDatabaseJson(json: object): M;
 
+    columnNameToPropertyName(columnName: string): string;
+    propertyNameToColumnName(propertyName: string): string;
+
     createValidator(): Validator;
     createValidationError(args: CreateValidationErrorArgs): Error;
     createNotFoundError(queryContext: QueryContext, args: CreateNotFoundErrorArgs): Error;
@@ -1582,6 +1585,9 @@ declare namespace Objection {
 
     static fromJson<M extends Model>(this: Constructor<M>, json: object, opt?: ModelOptions): M;
     static fromDatabaseJson<M extends Model>(this: Constructor<M>, json: object): M;
+
+    static columnNameToPropertyName(columnName: string): string;
+    static propertyNameToColumnName(propertyName: string): string;
 
     static createValidator(): Validator;
     static createValidationError(args: CreateValidationErrorArgs): Error;


### PR DESCRIPTION
### Fixed(#1898)

- [x] Add static method type for `Model.columnNameToPropertyName` in `typings/objection/index.d.ts`
- [x] Add static method type for `Model.propertyNameToColumnName` in `typings/objection/index.d.ts`