### PR TITLE
Fix argument types of onConflict

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1070,7 +1070,7 @@ declare namespace Objection {
     insert(insert: PartialModelObject<M>[]): ArrayQueryBuilder<this>;
     insert(): SingleQueryBuilder<this>;
 
-    onConflict(column?: string | string[] | true): this;
+    onConflict(column?: ColumnRef | ColumnRef[] | true): this;
     ignore(): this;
     merge(merge?: PartialModelObject<M> | string[]): this;
 


### PR DESCRIPTION
`onConflict` should accept any column reference, including `raw()` and `ref()` as input. This may be required to specify a conflict condition on a partial index. E.g. we use a query like this which works just fine for us:

```typescript
await Resource._query()
  .insert(resources)
  .onConflict(raw(`(aka) where status != 'DELETED'`))
  .merge()
```

This is explicitly supported by knex: https://knexjs.org/guide/query-builder.html#onconflict