### PR TITLE
CI: add Node 22 to version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node 22 just became the "current" Node.js release and will be the next LTS version. Add it to version matrix in CI.