### PR TITLE
QueryBuilder typing missing constructor types

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -854,6 +854,8 @@ declare namespace Objection {
   }
 
   export class QueryBuilder<M extends Model, R = M[]> implements CatchablePromiseLike<R> {
+    constructor(modelClass: ModelClass<M>);
+    
     static forClass: ForClassMethod;
 
     select: SelectMethod<this>;


### PR DESCRIPTION
the current typing told me there were no params in the constructor which doesn't line up with the actual code. ...args contains the model class.

If we don't pass the modelClass to super, we get errors

<img width="775" alt="image" src="https://github.com/Vincit/objection.js/assets/4983282/00737731-1ecd-4798-8862-056ef8b3609b">
