### PR TITLE
fix: naming mismatch between documentation and example

### DIFF
--- a/doc/recipes/modifiers.md
+++ b/doc/recipes/modifiers.md
@@ -50,7 +50,7 @@ Note that you can only use modifiers registered for the relation's model class. 
 
 ```js
 const people = await Person.query().withGraphFetched(
-  '[children(defaultSelects), pets(onlyDogs)]'
+  '[children(defaultSelects), pets(filterDogs)]'
 );
 ```
 


### PR DESCRIPTION
Just came across this typo while browsing the documentation.

That is all :)