### PR TITLE
[typings] Make trx optional for Model.transaction(trx, cb)

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1602,7 +1602,7 @@ declare namespace Objection {
 
     static transaction<T>(callback: (trx: Transaction) => Promise<T>): Promise<T>;
     static transaction<T>(
-      trxOrKnex: TransactionOrKnex,
+      trxOrKnex: TransactionOrKnex | undefined,
       callback: (trx: Transaction) => Promise<T>,
     ): Promise<T>;
 


### PR DESCRIPTION
Useful for "start a transaction or continue using an existing one"