### PR TITLE
static query hooks fixes: `modelOptions` in DelegateOperation should forward to the one from the delegated operation, resolve `modelOptions.old` properly for graph operations

### DIFF
--- a/lib/queryBuilder/graph/patch/GraphPatchAction.js
+++ b/lib/queryBuilder/graph/patch/GraphPatchAction.js
@@ -231,7 +231,10 @@ class GraphPatchAction extends GraphAction {
   }
 
   _createRootBuilder(node) {
-    return node.obj.$query();
+    const currentNode = this.currentGraph.nodeForNode(node);
+    const currentObj = currentNode && currentNode.obj;
+
+    return currentObj ? currentObj.$query() : node.obj.$query();
   }
 }
 

--- a/lib/queryBuilder/operations/DelegateOperation.js
+++ b/lib/queryBuilder/operations/DelegateOperation.js
@@ -11,6 +11,10 @@ class DelegateOperation extends QueryBuilderOperation {
     this.delegate = opt.delegate;
   }
 
+  get modelOptions() {
+    return this.delegate.modelOptions;
+  }
+
   is(OperationClass) {
     return super.is(OperationClass) || this.delegate.is(OperationClass);
   }


### PR DESCRIPTION
`modelOptions` in `DelegateOperation` should forward to the one from the delegated operation

- to make `modelOptions` always available in static query hooks, also when using upsertGraph(AndFetch) and patchAndFetchById
- also fix the query builder being executed on the model built from a graph instead of the source(current) model - the `modelOptions.old` should contain the old values read from db, not the new ones from the graph.