### PR TITLE
[feat] - Add knex updateFrom method

### DIFF
--- a/doc/api/query-builder/find-methods.md
+++ b/doc/api/query-builder/find-methods.md
@@ -303,6 +303,15 @@ See [knex documentation](https://knexjs.org/guide/query-builder.html#fromRaw)
 | ----------------------------------- | ---------------------------------- |
 | [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
 
+## updateFrom()
+
+See [knex documentation](https://knexjs.org/guide/query-builder.html#updatefrom)
+##### Return value
+
+| Type                                | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| [QueryBuilder](/api/query-builder/) | `this` query builder for chaining. |
+
 ## into()
 
 See [knex documentation](https://knexjs.org/guide/query-builder.html)

--- a/lib/queryBuilder/QueryBuilder.js
+++ b/lib/queryBuilder/QueryBuilder.js
@@ -922,6 +922,10 @@ class QueryBuilder extends QueryBuilderBase {
     return this.addOperation(new FromOperation('from'), args);
   }
 
+  updateFrom(...args) {
+    return this.addOperation(new KnexOperation('updateFrom'), args);
+  }
+
   table(...args) {
     return this.addOperation(new FromOperation('table'), args);
   }


### PR DESCRIPTION
Adds updateFrom method from Knex

https://knexjs.org/guide/query-builder.html#updatefrom

Currently we cannot call .updateFrom on a model:

```js
    myModel
      .query(trx)
      .with('a_cte', cteSubquery)
      .patch({
        ...
      })
      .updateFrom('a_cte')
      .whereRaw('my_table.id = a_cte.id');
```

Returns `TypeError: myModel.query(...).with(...).patch(...).whereRaw(...).updateFrom is not a function`

This works, but I would prefer to be able to call `.updateFrom` directly

```js
    myModel
      .query(trx)
      .with('a_cte', cteSubquery)
      .patch({
        ...
      })
      .whereRaw('my_table.id = a_cte.id');
      .toKnexQuery()
      .updateFrom('a_cte');
```