### PR TITLE
CI: add Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node 24 is latest "current" version of node and upcoming LTS. Add it to test matrix to ensure Objection.js keeps working with latest versions.